### PR TITLE
Added docker-compose override

### DIFF
--- a/docker-compose.override.yaml
+++ b/docker-compose.override.yaml
@@ -1,0 +1,26 @@
+version: '3.2'
+
+services:
+    buffalogs:
+        volumes:
+            - ./buffalogs:/opt/certego/buffalogs
+    celery:
+        volumes:
+            - ./buffalogs:/opt/certego/buffalogs
+
+    celery_beat:
+        volumes:
+            - ./buffalogs:/opt/certego/buffalogs
+
+    postgres:
+        ports:
+            - "127.0.0.1:5432:5432"
+    
+    rabbitmq:
+        ports:
+            - "127.0.0.1:5672:5672"
+            - "127.0.0.1:15672:15672"
+
+    elasticsearch:
+        ports:
+            - "127.0.0.1:9200:9200"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,8 +10,8 @@ services:
             - config/buffalogs/buffalogs.env
         volumes:
             - postgres_data:/var/lib/postgresql/data
-        ports:
-            - "127.0.0.1:5432:5432"
+        expose:
+            - "5432"
         
     elasticsearch:
         container_name: buffalogs_elasticsearch
@@ -31,12 +31,8 @@ services:
                 hard: -1
         expose:
             - "9200"
-        ports:
-            - "127.0.0.1:9200:9200"
         volumes:
             - elasticsearch_data:/usr/share/elasticsearch/data
-        expose:
-            - "9200"
         healthcheck:
             test: curl -XGET 'localhost:9200/_cluster/health?wait_for_status=yellow&timeout=180s&pretty'
 
@@ -51,8 +47,6 @@ services:
             - elasticsearch
         depends_on:
             - elasticsearch
-        expose:
-            - "5601"
         ports:
             - "127.0.0.1:5601:5601"
         healthcheck:
@@ -101,9 +95,6 @@ services:
         expose:
             - "5672"
             - "15672"
-        ports:
-            - "5672:5672"
-            - "15672:15672"
         healthcheck:
             test: rabbitmqctl status
 


### PR DESCRIPTION
Added docker-compose override with developer settings.

See documentation: https://docs.docker.com/compose/extends/

With this PR the following command will create containers with the configuration on both docker-compose files:
```
sudo docker-compose up -d
```

This is the developer configuration: every container also exposes ports on the phisical machine and you can run django natively.
It also maps the local code directary (`./buffalogs`) on the containers so every change on the code can be tested without rebuilding the container

If you want to run the containers in "production"  mode (without exposing additional ports) you can run it with the following command:

```
sudo docker-compose -f docker-compose.yaml up -d
```
