### PR TITLE
Added explicit version number to AG-Grid script source to fix javascript

### DIFF
--- a/buffalogs/impossible_travel/constants.py
+++ b/buffalogs/impossible_travel/constants.py
@@ -81,7 +81,7 @@ class AlertFilterType(models.TextChoices):
     * IGNORED_USER_FILTER: Alert filtered because the user is ignored - the user is in the Config.ignored_users list or Config.enabled_users list is populated
     * IGNORED_IP_FILTER: Alert filtered because the IP is ignored - the ip is in the Config.ignored_ips list
     * ALLOWED_COUNTRY_FILTER: Alert filtered because the country is whitelisted - the country is in the Config.allowed_countries list
-    * IS_VIP_FILTER: Alert filtered because the user is not vip - Config.alert_is_vip_only is True and the usre is not in the Config.vip_users list
+    * IS_VIP_FILTER: Alert filtered because the user is not vip - Config.alert_is_vip_only is True and the user is not in the Config.vip_users list
     * ALERT_MINIMUM_RISK_SCORE_FILTER: Alert filtered because the User.risk_score is lower than the threshold set in Config.alert_minimum_risk_score
     * FILTERED_ALERTS: Alert filtered because this detection type is excluded - the Alert.name detection type is in the Config.filtered_alerts_types list
     * IS_MOBILE_FILTER: Alert filtered because the login is from a mobile device - Config.ignore_mobile_logins is True
@@ -96,7 +96,7 @@ class AlertFilterType(models.TextChoices):
         "Alert filtered because the country is whitelisted - the country is in the Config.allowed_countries list"
     )
     IS_VIP_FILTER = "is_vip_filter", _(
-        "Alert filtered because the user is not vip - Config.alert_is_vip_only is True and the usre is not in the Config.vip_users list"
+        "Alert filtered because the user is not vip - Config.alert_is_vip_only is True and the user is not in the Config.vip_users list"
     )
     ALERT_MINIMUM_RISK_SCORE_FILTER = "alert_minimum_risk_score filter", _(
         "Alert filtered because the User.risk_score is lower than the threshold set in Config.alert_minimum_risk_score"

--- a/buffalogs/impossible_travel/templates/impossible_travel/alerts.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/alerts.html
@@ -4,11 +4,9 @@
 {% block title %} Alerts {% endblock %} 
 
 {% block head_content %} 
-   <link rel="stylesheet"
-     href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css"/>
 
-     <link rel="stylesheet"
-     href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css"/>
+     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
 
      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
 
@@ -30,6 +28,6 @@
 
 {% block extend_scripts %} 
     <!-- Include the JS for AG Grid -->
-    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
     <script src="{% static 'js/alerts.js' %}"></script>
 {% endblock %}

--- a/buffalogs/impossible_travel/templates/impossible_travel/all_logins.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/all_logins.html
@@ -4,11 +4,9 @@
 {% block title %} All logins {% endblock %} 
 
 {% block head_content %} 
-    <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css"/>
-      <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css"/>
-     
+
+    <link rel="stylesheet" href="{% static 'css/homepage.css' %}">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
     <link rel="stylesheet" href="{% static 'css/all_logins.css' %}"> 
 
 {% endblock %} 
@@ -24,6 +22,6 @@
 {% endblock %} 
 
 {% block extend_scripts %} 
-    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
     <script src="{% static 'js/all_logins.js' %}"></script>
 {% endblock %}

--- a/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
@@ -8,8 +8,8 @@
 {% block head_content %}
 
     <link rel="stylesheet" href="{% static 'css/homepage.css' %}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.css" />
 
     <meta name="viewport" content="width=device-width, initial-scale=1.0"> 
@@ -75,7 +75,7 @@
 
 {% block extend_scripts %}
     <script src="https://kit.fontawesome.com/a076d05399.js" crossorigin="anonymous"></script>
-    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/jquery/latest/jquery.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/momentjs/latest/moment.min.js"></script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/daterangepicker/daterangepicker.min.js"></script>

--- a/buffalogs/impossible_travel/templates/impossible_travel/unique_logins.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/unique_logins.html
@@ -4,10 +4,8 @@
 {% block title %} All logins {% endblock %} 
 
 {% block head_content %} 
-    <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css"/>
-      <link rel="stylesheet"
-      href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css"/>
+     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
      
     <link rel="stylesheet" href="{% static 'css/unique_logins.css' %}"> 
 
@@ -24,6 +22,6 @@
 {% endblock %} 
 
 {% block extend_scripts %} 
-    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
     <script src="{% static 'js/unique_logins.js' %}"></script>
 {% endblock %}

--- a/buffalogs/impossible_travel/templates/impossible_travel/users.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/users.html
@@ -5,8 +5,8 @@
 
 {% block head_content %}
 
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-grid.css"/>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community/styles/ag-theme-alpine.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
   <link rel="stylesheet" href="{% static 'css/users.css' %}">
 
@@ -26,6 +26,6 @@
 
 {% block extend_scripts %} 
     <!-- Include the JS for AG Grid -->
-    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community/dist/ag-grid-community.min.noStyle.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
     <script src="{% static 'js/users.js' %}"></script>
 {% endblock %}


### PR DESCRIPTION

![Screenshot from localhost:80/homepage](https://github.com/user-attachments/assets/61a25090-b526-48a9-b57d-c2e564fdd8b9)

The homepage and users page view of buffalogs doesn't load due to an update on the ag-Grid API which breaks the current code in `users.js and homepage.js`. A possible solution is to update each `js` to fit the new standard but this PR opted for the easier fix of explicitly stating the version of ag-Grid to use to avoid future breaks regardless of API updates

Also, I corrected a typo `usre` in impossible_travel.constants.py.

Files changes:

- homepage.html
- alerts.html
- users.html
- all_logins.html
- unique_login.html
- constant.py [typo]


All `.html` file edits are similar and involve updating the ag-Grid CSS link and script tag to

```
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">                                                                                              
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css"> 
    
    <script src="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/dist/ag-grid-community.min.noStyle.js"></script>
```

### Before update
![Screenshot of homepage console](https://github.com/user-attachments/assets/e672fd2c-75dc-4e1f-a345-548670f96e69)

### After update
![Screenshot from homepage console ](https://github.com/user-attachments/assets/0aa4e3e1-1059-4acd-9aa3-0b76428e2878)
