### PR TITLE
Added Slack Alerter Functionality

### DIFF
--- a/buffalogs/impossible_travel/alerting/alert_factory.py
+++ b/buffalogs/impossible_travel/alerting/alert_factory.py
@@ -1,8 +1,10 @@
+import json
+import os
+
+from django.conf import settings
 from impossible_travel.alerting.base_alerting import BaseAlerting
 from impossible_travel.alerting.dummy_alerting import DummyAlerting
-import os
-import json
-from django.conf import settings
+from impossible_travel.alerting.slack_alerting import SlackAlerting
 
 
 class AlertFactory:
@@ -38,6 +40,8 @@ class AlertFactory:
         match self.active_alerter:
             case BaseAlerting.SupportedAlerters.DUMMY:
                 alerter_class = DummyAlerting(self.alert_config)
+            case BaseAlerting.SupportedAlerters.SLACK:
+                alerter_class = SlackAlerting(self.alert_config)
             case _:
                 raise ValueError(f"Unsupported alerter: {self.active_alerter}")
         return alerter_class

--- a/buffalogs/impossible_travel/alerting/base_alerting.py
+++ b/buffalogs/impossible_travel/alerting/base_alerting.py
@@ -1,6 +1,6 @@
+import logging
 from abc import ABC, abstractmethod
 from enum import Enum
-import logging
 
 
 class BaseAlerting(ABC):
@@ -10,6 +10,7 @@ class BaseAlerting(ABC):
 
     class SupportedAlerters(Enum):
         DUMMY = "dummy"
+        SLACK = "slack"
 
     def __init__(self):
         super().__init__()

--- a/buffalogs/impossible_travel/alerting/slack_alerting.py
+++ b/buffalogs/impossible_travel/alerting/slack_alerting.py
@@ -1,0 +1,37 @@
+import json
+
+import requests
+from impossible_travel.alerting.base_alerting import BaseAlerting
+from impossible_travel.models import Alert
+
+
+class SlackAlerting(BaseAlerting):
+    def __init__(self, alert_config: dict):
+        """
+        Constructor for the Slack Alerter object.
+        """
+        super().__init__()
+        self.webhook_url = alert_config.get("webhook_url")
+        if not self.webhook_url:
+            self.logger.error("Missing required 'webhook_url' in alert_config")
+
+    def notify_alerts(self):
+        """
+        Execute the alerter operation - send all unnotified alerts to Slack.
+        """
+        alerts = Alert.objects.filter(notified=False)
+
+        for alert in alerts:
+            # alert message
+            alert_msg = (
+                f"Login Anomaly Alert: {alert.name}\nDear user,\n\nAn unusual login activity has been detected:\n\n{alert.description}\n\nStay Safe,\nBuffalogs"
+            )
+
+            payload = {"text": alert_msg}
+            response = requests.post(self.webhook_url, data=json.dumps(payload), headers={"Content-Type": "application/json"})
+            if response.status_code != 200:
+                self.logger.error("Failed to send alert to Slack (status %s): %s", response.status_code, response.text)
+
+            self.logger.info("Alerting Slack about: %s", alert.name)
+            alert.notified = True
+            alert.save()

--- a/buffalogs/impossible_travel/modules/impossible_travel.py
+++ b/buffalogs/impossible_travel/modules/impossible_travel.py
@@ -46,9 +46,9 @@ class Impossible_Travel:
 
             if vel > app_config.vel_accepted:
                 alert_info["alert_name"] = AlertDetectionType.IMP_TRAVEL.value
-                alert_info[
-                    "alert_desc"
-                    ] = (f"{AlertDetectionType.IMP_TRAVEL.label} for User: {db_user.username}, at: {last_login_user_fields['timestamp']}, from: {last_login_user_fields['country']}, previous country: {prev_login.country}, distance covered at {int(vel)} Km/h")
+                alert_info["alert_desc"] = (
+                    f"{AlertDetectionType.IMP_TRAVEL.label} for User: {db_user.username}, at: {last_login_user_fields['timestamp']}, from: {last_login_user_fields['country']}, previous country: {prev_login.country}, distance covered at {int(vel)} Km/h"
+                )
         return alert_info, int(vel)
 
     def update_model(self, db_user, new_login):

--- a/buffalogs/impossible_travel/tasks.py
+++ b/buffalogs/impossible_travel/tasks.py
@@ -7,10 +7,10 @@ from django.db import transaction
 from django.db.models import Count
 from django.utils import timezone
 from elasticsearch_dsl import Search, connections
+from impossible_travel.alerting.alert_factory import AlertFactory
 from impossible_travel.constants import UserRiskScoreType
 from impossible_travel.models import Alert, Config, Login, TaskSettings, User, UsersIP
 from impossible_travel.modules import alert_filter, impossible_travel, login_from_new_country, login_from_new_device
-from impossible_travel.alerting.alert_factory import AlertFactory
 
 logger = get_task_logger(__name__)
 

--- a/buffalogs/impossible_travel/tests/test_alert_slack.py
+++ b/buffalogs/impossible_travel/tests/test_alert_slack.py
@@ -1,0 +1,41 @@
+import json
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+from impossible_travel.alerting.slack_alerting import SlackAlerting
+from impossible_travel.models import Alert, Login, User
+
+
+class TestTelegramAlerting(TestCase):
+    def setUp(self):
+        """Set up test data before running tests."""
+
+        self.slack_config = {"webhook_url": "YOUR_WEBHOOK_URL"}
+        self.slack_alerting = SlackAlerting(self.slack_config)
+
+        # Create a dummy user
+        self.user = User.objects.create(username="testuser")
+        Login.objects.create(user=self.user, id=self.user.id)
+
+        # Create an alert
+        self.alert = Alert.objects.create(name="Imp Travel", user=self.user, notified=False, description="Impossible travel detected", login_raw_data={})
+
+    @patch("requests.post")
+    def test_send_alert(self, mock_post):
+        """Doesn't actually sends the Alert,a mock request is sent"""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_post.return_value = mock_response
+
+        self.slack_alerting.notify_alerts()
+
+        # \\n because we are comparing string literals
+        expected_payload = {
+            "text": "Login Anomaly Alert: Imp Travel\nDear user,\n\nAn unusual login activity has been detected:\n\nImpossible travel detected\n\nStay Safe,\nBuffalogs"
+        }
+
+        mock_post.assert_called_once_with("YOUR_WEBHOOK_URL", data=json.dumps(expected_payload), headers={"Content-Type": "application/json"})
+
+    def test_send_actual_alert(self):
+        """Sending actual alert message to the channel"""
+        self.slack_alerting.notify_alerts()

--- a/config/buffalogs/alerting.json
+++ b/config/buffalogs/alerting.json
@@ -2,5 +2,8 @@
     "active_alerter": "dummy",
     "dummy": {
         "config_field_example": "value_example"
+    },
+    "slack":{
+        "webhook_url":"YOUR_WEBHOOK_URL"
     }
 }

--- a/docs/alerting/slack.md
+++ b/docs/alerting/slack.md
@@ -1,0 +1,32 @@
+# Adding a Slack Alerter to BuffaLogs
+
+This document outlines the steps to add a **Slack** alerter to BuffaLogs to receive alerts via the [Slack Incoming Webhooks](https://api.slack.com/messaging/webhooks).
+
+---
+
+## Steps to Implement
+
+### 1. Create a Webhook URL
+- Create a new workspace on your Slack,if you don't have one already.
+- Create an app from [Slack API: Applications](https://api.slack.com/apps?new_app=1)
+- Choose **From Scratch** and give your app a name.
+- Select the Slack workspace where you want to install the app.
+- Once created, navigate to **Incoming Webhooks** under the "Features" section.
+- Enable **Incoming Webhooks**.
+- Click **Add New Webhook to Workspace** and choose the channel where alerts should be posted.
+- Copy the generated **Webhook URL** — you’ll need this in the BuffaLogs configuration.
+---
+
+### 2. Update Configuration File
+- Update `config/buffalogs/alerting.json` with Slack WebHook details:
+
+```json
+{
+    "active_alerter": "slack",
+    "slack": {
+        "webhook_url": "your-webhook-url",
+    }
+}
+```
+
+---


### PR DESCRIPTION
In reference to the issue #136 
For full documentation on how to implement and use it refer to `docs/alerting/slack.md`

## Changes made
- New Slack alerting module implemented using `webhook_url` and `requests.post`
- Users can receive alerts on their Slack Channels

## Outcomes
- All tests are getting passed.
- Alerts being received on the slack channel

@ManofWax looking forward to your insights !