### PR TITLE
Update docker compose file for elasticsearch containers

### DIFF
--- a/docker-compose.elastic.yaml
+++ b/docker-compose.elastic.yaml
@@ -19,6 +19,8 @@ services:
             - "9200:9200"
         volumes:
             - elasticsearch_data:/usr/share/elasticsearch/data
+        networks:
+            - elk
         healthcheck:
             test: curl -XGET 'localhost:9200/_cluster/health?wait_for_status=yellow&timeout=180s&pretty'
 
@@ -29,8 +31,8 @@ services:
         environment:
             ELASTICSEARCH_URL: http://elasticsearch:9200
             ELASTICSEARCH_HOSTS: http://elasticsearch:9200
-        links:
-            - elasticsearch
+        networks:
+            - elk
         depends_on:
             - elasticsearch
         ports:
@@ -39,6 +41,9 @@ services:
             test: curl -fs http://localhost:5601/
 
 volumes:
-
     elasticsearch_data:
         driver: local
+
+networks:
+    elk:
+        driver: bridge


### PR DESCRIPTION
`links` is a legacy feature of Docker and will be soon deprecated. On top of it, Podman doesn't support `links` as well, so it will be better if we start using the Bridge network driver - https://docs.docker.com/engine/network/drivers/bridge by explicitly defining `networks` in the `docker-compose` files. With reference to this article - https://docs.docker.com/engine/network/links, it is evident that the only feature that `networks` doesn't support is shared environment variables. But since we are already using `volumes`, that won't be a problem and we can safely migrate.

<img width="686" alt="image" src="https://github.com/user-attachments/assets/35bb1819-3ad6-4ee3-8465-1087ed3c272f" />
