### PR TITLE
Refactor run.sh 

### DIFF
--- a/buffalogs/run.sh
+++ b/buffalogs/run.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
 
-# Apply migration before starting uwsgi
-python /opt/certego/buffalogs/manage.py migrate
+# Change the working directory
+cd /opt/certego/buffalogs/
 
+# Apply migration before starting uwsgi
+python manage.py migrate
 
 # Manage static files
 python manage.py collectstatic --noinput --clear
 
 # Run server
-uwsgi --ini /opt/certego/buffalogs/buffalogs_uwsgi.ini
+uwsgi --ini buffalogs_uwsgi.ini
 


### PR DESCRIPTION
In reference to the issue #222 

- `run.sh` has been refactored by changing directory in the first line
- This prevents any errors/issues related to path

@Lorygold @ManofWax Looking forward to your insights !