### PR TITLE
fix csrf forbidden error

### DIFF
--- a/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
@@ -15,6 +15,9 @@
 {% endblock %}
 
 {% block body_content %}
+  <form style="display:none;">
+  {% csrf_token %}
+  </form>
   <div class="d-flex justify-content-lg-start justify-content-center" id="reportrange" data-startdate="{{startdate}}" data-enddate="{{enddate}}">
     <a href="#" class="btn bg-grey me-2 text-truncate text-light" id="daterange-filter">
       <i class="fa fa-calendar"></i> 


### PR DESCRIPTION
ref : #238 
I used the {% csrf_token %} inside a hidden form to fix the CSRF error. This token is required for forms to protect against Cross-Site Request Forgery (CSRF) attacks. By including this token, I ensured that the form submission is validated and the server can verify that the request is coming from an authorized user, resolving the CSRF error.

