### PR TITLE
Fixed user-agent parsing in case of a "None" os

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## 2.x.x
+### 2.1.1
+### Bugfix
+* Fixed user-agent parsing in case of a "None" os
 ### 2.1.0
 #### Features
 * Added the `Ingestion` process

--- a/buffalogs/impossible_travel/modules/alert_filter.py
+++ b/buffalogs/impossible_travel/modules/alert_filter.py
@@ -35,7 +35,7 @@ def match_filters(alert: Alert, app_config: Config) -> Alert:
         alert.filter_type.append(AlertFilterType.IGNORED_ISP_FILTER)
     if app_config.ignore_mobile_logins and alert.login_raw_data["agent"]:
         ua_parsed = parse(alert.login_raw_data["agent"])
-        if ua_parsed.os.family in settings.CERTEGO_BUFFALOGS_MOBILE_DEVICES:
+        if ua_parsed.os and ua_parsed.os.family in settings.CERTEGO_BUFFALOGS_MOBILE_DEVICES:
             logger.debug(
                 f"Alert: {alert.id} filtered for user: {db_user.username} because the login user-agent: {alert.login_raw_data['agent']} is a mobile device and Config.ignore_mobile_logins: {app_config.ignore_mobile_logins}"
             )

--- a/buffalogs/impossible_travel/tests/test_alert_filter.py
+++ b/buffalogs/impossible_travel/tests/test_alert_filter.py
@@ -361,3 +361,11 @@ class TestAlertFilter(TestCase):
             ],
             db_alert.filter_type,
         )
+
+    def test_match_filters_uaparsed_none_os(self):
+        # test with a user_agent that has "None" as os
+        db_config = Config.objects.create(id=1)
+        none_agent = "Mozilla/5.0 (compatible; MSAL 1.0) PKeyAuth/1.0"
+        db_alert = Alert.objects.get(user__username="Lorena Goldoni")
+        db_alert.login_raw_data["agent"] = none_agent
+        alert_filter.match_filters(alert=db_alert, app_config=db_config)


### PR DESCRIPTION
Fix for error:
```
Task BuffalogsProcessLogsTask[4e2bab36-d987-472a-ad92-2ef4a6003f94] raised unexpected: AttributeError("'NoneType' object has no attribute 'family'")

  File "/usr/local/lib/python3.12/site-packages/impossible_travel/modules/alert_filter.py", line 38, in match_filters
    if ua_parsed.os.family in settings.CERTEGO_BUFFALOGS_MOBILE_DEVICES:
       ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'family'
```