### PR TITLE
[REFACTOR] backend/ingestion: unify all custom_mapping via common_custom_mapping

### DIFF
--- a/config/buffalogs/ingestion.json
+++ b/config/buffalogs/ingestion.json
@@ -1,65 +1,24 @@
 {
+  "common_custom_mapping": {
+    "@timestamp":              "timestamp",
+    "_id":                     "id",
+    "_index":                  "index",
+    "user.name":               "username",
+    "source.ip":               "ip",
+    "user_agent.original":     "agent",
+    "source.as.organization.name": "organization",
+    "source.geo.country_name": "country",
+    "source.geo.location.lat":  "lat",
+    "source.geo.location.lon":  "lon"
+  },
     "active_ingestion": "elasticsearch",
     "elasticsearch": {
-        "url": "http://elasticsearch:9200/",
-        "username": "foobar",
-        "password": "bar",
-        "timeout": 90,
-        "indexes": "cloud-*,fw-proxy-*",
-        "bucket_size": 10000,
-        "custom_mapping": {
-            "@timestamp": "timestamp",
-            "_id": "id",
-            "_index": "index",
-            "user.name": "username",
-            "source.ip": "ip",
-            "user_agent.original": "agent",
-            "source.as.organization.name": "organization",
-            "source.geo.country_name": "country",
-            "source.geo.location.lat": "lat",
-            "source.geo.location.lon": "lon"
-        }
+        "custom_mapping": "${common_custom_mapping}"
     },
     "opensearch": {
-        "url": "http://opensearch:9200/",
-        "username": "foobar",
-        "password": "bar",
-        "timeout": 90,
-        "indexes": "cloud-*,fw-proxy-*",
-        "bucket_size": 10000,
-        "custom_mapping": {
-            "timestamp": "@timestamp",
-            "id": "id",
-            "index": "index",
-            "username": "user.name",
-            "ip": "source.ip",
-            "agent": "source.user_agent.original",
-            "organization": "source.as.organization.name",
-            "country": "source.geo.country_name",
-            "lat": "source.geo.location.lat",
-            "lon": "source.geo.location.lon"
-        }
+      "custom_mapping": "${common_custom_mapping}"
     },
     "splunk": {
-        "host": "splunk",
-        "port": 8089,
-        "scheme": "http",
-        "username": "foobar",
-        "password": "bar",
-        "timeout": 90,
-        "indexes": "main",
-        "bucket_size": 10000,
-        "custom_mapping": {
-            "user.name": "username",
-            "@timestamp": "timestamp",
-            "source.ip": "ip",
-            "source.geo.country_name": "country",
-            "source.geo.location.lat": "lat",
-            "source.geo.location.lon": "lon",
-            "user_agent.original": "agent",
-            "source.as.organization.name": "organization",
-            "_id": "id",
-            "index": "index"
-        }
+       "custom_mapping": "${common_custom_mapping}"
       }
 }

--- a/frontend/lib/requestdata.ts
+++ b/frontend/lib/requestdata.ts
@@ -3,91 +3,63 @@ import { BASE_URL } from "./constants";
 
 export const timestampFormat = "YYYY-MM-DDTHH:mm:ssZ";
 
-export async function getUsersPieChart(dateRange?: DateRange): Promise<any> {
+// Common date‐range formatter
+function formatDateRange(dateRange?: DateRange) {
     if (dateRange && dateRange.from && dateRange.to) {
-      const start = dateRange.from.toISOString().slice(0, -5) + "Z";
-      const end = dateRange.to.toISOString().slice(0, -5)+ "Z";
-  
-      const url = `${BASE_URL}/users_pie_chart_api?start=${start}&end=${end}`;
-      try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Failed to fetch users pie chart data');
-        }
-        const data = await response.json();
-        return data;    
-      } catch (error) {
-        console.error(error);
-        throw new Error('Failed to fetch users pie chart data');
-      }
-    } else {
-      throw new Error('Invalid date range');
+        const start = dateRange.from.toISOString().slice(0, -5) + "Z";
+        const end   = dateRange.to.toISOString().slice(0, -5)   + "Z";
+        return { start, end };
     }
-  }
-  
-export async function getAlertsLineChart(dateRange?: DateRange): Promise<any> {
-    if (dateRange && dateRange.from && dateRange.to) {
-      const start = dateRange.from.toISOString().slice(0, -5) + "Z";
-      const end = dateRange.to.toISOString().slice(0, -5)+ "Z";
-  
-      const url = `${BASE_URL}/alerts_line_chart_api?start=${start}&end=${end}`;
-      try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Failed to fetch users alerts chart data');
-        }
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        console.error(error);
-        throw new Error('Failed to fetch users alerts chart data');
-      }
-    } else {
-      throw new Error('Invalid date range');
-    }
-  }
-  
-export async function getWorldMapChart(dateRange?: DateRange): Promise<any> {
-    if (dateRange && dateRange.from && dateRange.to) {
-      const start = dateRange.from.toISOString().slice(0, -5) + "Z";
-      const end = dateRange.to.toISOString().slice(0, -5)+ "Z";
-  
-      const url = `${BASE_URL}/world_map_chart_api?start=${start}&end=${end}`;
-      try {
-        const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Failed to fetch users world chart data');
-        }
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        console.error(error);
-        throw new Error('Failed to fetch users world chart data');
-      }
-    } else {
-      throw new Error('Invalid date range');
-    }
-  }
+    throw new Error("Invalid date range");
+}
 
-  export async function getAlerts(dateRange?: DateRange): Promise<any> {
-    if (dateRange && dateRange.from && dateRange.to) {
-      const start = dateRange.from.toISOString().slice(0, -5) + "Z";
-      const end = dateRange.to.toISOString().slice(0, -5)+ "Z";
-  
-      const url = `${BASE_URL}/alerts_api?start=${start}&end=${end}`;
-      try {
+// Generic fetch + error handler
+async function fetchData(
+    endpoint: string,
+    errorMessage: string,
+    dateRange?: DateRange
+): Promise<any> {
+    const { start, end } = formatDateRange(dateRange);
+    const url = `${BASE_URL}/${endpoint}?start=${start}&end=${end}`;
+    try {
         const response = await fetch(url);
-        if (!response.ok) {
-          throw new Error('Failed to fetch alerts');
-        }
-        const data = await response.json();
-        return data;
-      } catch (error) {
-        console.error(error);
-        throw new Error('Failed to fetch alerts');
-      }
-    } else {
-      throw new Error('Invalid date range');
+        if (!response.ok) throw new Error(errorMessage);
+        return await response.json();
+    } catch (err) {
+        console.error(err);
+        throw new Error(errorMessage);
     }
-  }
-  
+}
+
+// Each API function now delegates to fetchData
+export async function getUsersPieChart(dateRange?: DateRange): Promise<any> {
+    return fetchData(
+        "users_pie_chart_api",
+        "Failed to fetch users pie chart data",
+        dateRange
+    );
+}
+
+export async function getAlertsLineChart(dateRange?: DateRange): Promise<any> {
+    return fetchData(
+        "alerts_line_chart_api",
+        "Failed to fetch users alerts chart data",
+        dateRange
+    );
+}
+
+export async function getWorldMapChart(dateRange?: DateRange): Promise<any> {
+    return fetchData(
+        "world_map_chart_api",
+        "Failed to fetch users world chart data",
+        dateRange
+    );
+}
+
+export async function getAlerts(dateRange?: DateRange): Promise<any> {
+    return fetchData(
+        "alerts_api",
+        "Failed to fetch alerts",
+        dateRange
+    );
+}


### PR DESCRIPTION
This PR addresses the inconsistent direction and duplicate‑key issues in our ingestion.json and ingestion factory by:

- Extracting all field mappings into a single common_custom_mapping object in ingestion.json, eliminating duplicates and guaranteeing a single source of truth.
- Post‑processing the raw JSON in IngestionFactory._read_config() so that any "${common_custom_mapping}" placeholder is immediately replaced with the actual dict for all backends.
- Simplifying the constructor in IngestionFactory.__init__() to pick up the now‑resolved mapping without needing to special‑case Elasticsearch vs. Splunk.