### PR TITLE
refactor(ingestion_factory): consolidate custom‑mapping logic & fix Flake8 issues

### DIFF
--- a/buffalogs/impossible_travel/ingestion/ingestion_factory.py
+++ b/buffalogs/impossible_travel/ingestion/ingestion_factory.py
@@ -7,8 +7,12 @@ from impossible_travel.ingestion.base_ingestion import BaseIngestion
 from impossible_travel.ingestion.elasticsearch_ingestion import (
     ElasticsearchIngestion,
 )
-from impossible_travel.ingestion.opensearch_ingestion import OpensearchIngestion
-from impossible_travel.ingestion.splunk_ingestion import SplunkIngestion
+from impossible_travel.ingestion.opensearch_ingestion import (
+    OpensearchIngestion,
+)
+from impossible_travel.ingestion.splunk_ingestion import (
+    SplunkIngestion,
+)
 
 
 class IngestionFactory:
@@ -48,16 +52,12 @@ class IngestionFactory:
                 config[backend]["custom_mapping"] = common_map
 
         supported = [i.value for i in BaseIngestion.SupportedIngestionSources]
-        if config["active_ingestion"] not in supported:
-            raise ValueError(
-                f"Ingestion source '{config['active_ingestion']}' " "is not supported"
-            )
+        src = config["active_ingestion"]
+        if src not in supported:
+            raise ValueError(f"Ingestion source '{src}' is not supported")
 
-        if not config.get(config["active_ingestion"]):
-            raise ValueError(
-                f"Configuration for '{config['active_ingestion']}' "
-                "must be implemented"
-            )
+        if not config.get(src):
+            raise ValueError(f"Configuration for '{src}' must be implemented")
 
         return config
 
@@ -65,12 +65,21 @@ class IngestionFactory:
         """Return the instantiated ingestion class for the active backend."""
         match self.active_ingestion:
             case BaseIngestion.SupportedIngestionSources.ELASTICSEARCH:
-                return ElasticsearchIngestion(self.ingestion_config, self.mapping)
+                return ElasticsearchIngestion(
+                    self.ingestion_config,
+                    self.mapping,
+                )
             case BaseIngestion.SupportedIngestionSources.OPENSEARCH:
-                return OpensearchIngestion(self.ingestion_config)
+                return OpensearchIngestion(
+                    self.ingestion_config,
+                )
             case BaseIngestion.SupportedIngestionSources.SPLUNK:
-                return SplunkIngestion(self.ingestion_config, self.mapping)
+                return SplunkIngestion(
+                    self.ingestion_config,
+                    self.mapping,
+                )
             case _:
                 raise ValueError(
-                    f"Unsupported ingestion source: " f"{self.active_ingestion}"
+                    f"Unsupported ingestion source: "
+                    f"{self.active_ingestion}"
                 )

--- a/buffalogs/impossible_travel/ingestion/ingestion_factory.py
+++ b/buffalogs/impossible_travel/ingestion/ingestion_factory.py
@@ -12,75 +12,65 @@ from impossible_travel.ingestion.splunk_ingestion import SplunkIngestion
 
 
 class IngestionFactory:
+    """Factory to build the right ingestion class from config."""
+
     def __init__(self):
         config = self._read_config()
         active = config["active_ingestion"]
         self.active_ingestion = BaseIngestion.SupportedIngestionSources(active)
         self.ingestion_config = config[active]
 
-        # pull in common mapping if referenced, otherwise use any backend override
-        common = config.get(
+        # pull in common mapping if referenced, otherwise use any override
+        common_map = config.get(
             "common_custom_mapping",
             config["elasticsearch"]["custom_mapping"],
         )
-        self.mapping = self.ingestion_config.get("custom_mapping", common)
+        self.mapping = self.ingestion_config.get("custom_mapping", common_map)
 
     def _read_config(self) -> dict:
-        """
-        Read the ingestion configuration file
-
-        :return: the configuration dict
-        :rtype: dict
-        """
+        """Load and validate ingestion.json, replace common mapping refs."""
         config_path = os.path.join(
             settings.CERTEGO_BUFFALOGS_CONFIG_PATH,
             "buffalogs",
             "ingestion.json",
         )
-        with open(config_path, mode="r", encoding="utf-8") as f:
+        with open(config_path, "r", encoding="utf-8") as f:
             config = json.load(f)
 
-        # replace any "${common_custom_mapping}" placeholders
-        common = config.get(
+        # Inline common mapping where requested
+        common_map = config.get(
             "common_custom_mapping",
             config["elasticsearch"]["custom_mapping"],
         )
         for backend in ("elasticsearch", "opensearch", "splunk"):
             cm = config.get(backend, {}).get("custom_mapping")
             if cm == "${common_custom_mapping}":
-                config[backend]["custom_mapping"] = common
+                config[backend]["custom_mapping"] = common_map
 
-        if config["active_ingestion"] not in [
-            i.value for i in BaseIngestion.SupportedIngestionSources
-        ]:
+        supported = [i.value for i in BaseIngestion.SupportedIngestionSources]
+        if config["active_ingestion"] not in supported:
             raise ValueError(
-                f"The ingestion source: {config['active_ingestion']} is not supported"
+                f"Ingestion source '{config['active_ingestion']}' " "is not supported"
             )
 
         if not config.get(config["active_ingestion"]):
             raise ValueError(
-                f"The configuration for the {config['active_ingestion']} "
+                f"Configuration for '{config['active_ingestion']}' "
                 "must be implemented"
             )
 
         return config
 
     def get_ingestion_class(self):
-        """
-        Return the ingestion class
-        """
+        """Return the instantiated ingestion class for the active backend."""
         match self.active_ingestion:
             case BaseIngestion.SupportedIngestionSources.ELASTICSEARCH:
-                return ElasticsearchIngestion(
-                    self.ingestion_config, self.mapping
-                )
+                return ElasticsearchIngestion(self.ingestion_config, self.mapping)
             case BaseIngestion.SupportedIngestionSources.OPENSEARCH:
                 return OpensearchIngestion(self.ingestion_config)
             case BaseIngestion.SupportedIngestionSources.SPLUNK:
-                return SplunkIngestion(
-                    self.ingestion_config, self.mapping
-                )
+                return SplunkIngestion(self.ingestion_config, self.mapping)
             case _:
                 raise ValueError(
-                    f"Unsupported ingestion source: {self.active_ingestion}"
+                    f"Unsupported ingestion source: " f"{self.active_ingestion}"
                 )

--- a/buffalogs/impossible_travel/ingestion/ingestion_factory.py
+++ b/buffalogs/impossible_travel/ingestion/ingestion_factory.py
@@ -2,8 +2,11 @@ import json
 import os
 
 from django.conf import settings
+
 from impossible_travel.ingestion.base_ingestion import BaseIngestion
-from impossible_travel.ingestion.elasticsearch_ingestion import ElasticsearchIngestion
+from impossible_travel.ingestion.elasticsearch_ingestion import (
+    ElasticsearchIngestion,
+)
 from impossible_travel.ingestion.opensearch_ingestion import OpensearchIngestion
 from impossible_travel.ingestion.splunk_ingestion import SplunkIngestion
 
@@ -11,28 +14,55 @@ from impossible_travel.ingestion.splunk_ingestion import SplunkIngestion
 class IngestionFactory:
     def __init__(self):
         config = self._read_config()
-        self.active_ingestion = BaseIngestion.SupportedIngestionSources(config["active_ingestion"])
-        self.ingestion_config = config[config["active_ingestion"]]
-        # default mapping: Elasticsearch mapping
-        self.mapping = self.ingestion_config.get("custom_mapping", config["elasticsearch"]["custom_mapping"])
+        active = config["active_ingestion"]
+        self.active_ingestion = BaseIngestion.SupportedIngestionSources(active)
+        self.ingestion_config = config[active]
+
+        # pull in common mapping if referenced, otherwise use any backend override
+        common = config.get(
+            "common_custom_mapping",
+            config["elasticsearch"]["custom_mapping"],
+        )
+        self.mapping = self.ingestion_config.get("custom_mapping", common)
 
     def _read_config(self) -> dict:
         """
         Read the ingestion configuration file
 
-        :return : the configuration dict
+        :return: the configuration dict
         :rtype: dict
         """
-        with open(
-            os.path.join(settings.CERTEGO_BUFFALOGS_CONFIG_PATH, "buffalogs/ingestion.json"),
-            mode="r",
-            encoding="utf-8",
-        ) as f:
+        config_path = os.path.join(
+            settings.CERTEGO_BUFFALOGS_CONFIG_PATH,
+            "buffalogs",
+            "ingestion.json",
+        )
+        with open(config_path, mode="r", encoding="utf-8") as f:
             config = json.load(f)
-        if config["active_ingestion"] not in [i.value for i in BaseIngestion.SupportedIngestionSources]:
-            raise ValueError(f"The ingestion source: {config['active_ingestion']} is not supported")
+
+        # replace any "${common_custom_mapping}" placeholders
+        common = config.get(
+            "common_custom_mapping",
+            config["elasticsearch"]["custom_mapping"],
+        )
+        for backend in ("elasticsearch", "opensearch", "splunk"):
+            cm = config.get(backend, {}).get("custom_mapping")
+            if cm == "${common_custom_mapping}":
+                config[backend]["custom_mapping"] = common
+
+        if config["active_ingestion"] not in [
+            i.value for i in BaseIngestion.SupportedIngestionSources
+        ]:
+            raise ValueError(
+                f"The ingestion source: {config['active_ingestion']} is not supported"
+            )
+
         if not config.get(config["active_ingestion"]):
-            raise ValueError(f"The configuration for the {config['active_ingestion']} must be implemented")
+            raise ValueError(
+                f"The configuration for the {config['active_ingestion']} "
+                "must be implemented"
+            )
+
         return config
 
     def get_ingestion_class(self):
@@ -41,10 +71,16 @@ class IngestionFactory:
         """
         match self.active_ingestion:
             case BaseIngestion.SupportedIngestionSources.ELASTICSEARCH:
-                return ElasticsearchIngestion(self.ingestion_config, self.mapping)
+                return ElasticsearchIngestion(
+                    self.ingestion_config, self.mapping
+                )
             case BaseIngestion.SupportedIngestionSources.OPENSEARCH:
                 return OpensearchIngestion(self.ingestion_config)
             case BaseIngestion.SupportedIngestionSources.SPLUNK:
-                return SplunkIngestion(self.ingestion_config, self.mapping)
+                return SplunkIngestion(
+                    self.ingestion_config, self.mapping
+                )
             case _:
-                raise ValueError(f"Unsupported ingestion source: {self.active_ingestion}")
+                raise ValueError(
+                    f"Unsupported ingestion source: {self.active_ingestion}"
+                )


### PR DESCRIPTION
- Simplified [__init__()](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) mapping resolution by unifying the fallback to [common_map](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
- Renamed temporary common variable to [common_map](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) for clarity and consistency
- Centralized ${common_custom_mapping} placeholder expansion in [_read_config()](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)
- Ensured two blank lines around the top‑level class and methods to comply with PEP8
- Grouped imports into standard‐library, third‑party, and local sections with blank lines between each group
- Broke long lines (including f‑strings and function calls) to stay within the project’s max‑length limit
- Converted multi‑line docstrings into single‑line summaries where appropriate
- Removed any trailing whitespace and fixed indentation to satisfy Flake8 linting rules
- Refactored [IngestionFactory](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) to unify custom mapping fallback into a single [common_map](vscode-file://vscode-app/d:/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html) and reformatted the file with Black for PEP8/Flake8 compliance.