### PR TITLE
Refactored alerts, unique_alerts and all_logins templates

### DIFF
--- a/buffalogs/impossible_travel/static/css/alerts.css
+++ b/buffalogs/impossible_travel/static/css/alerts.css
@@ -1,9 +1,9 @@
 body{
     background-color: #dee2e6;
 }
+
 #myGrid{
-    width: 80%;
-    position: absolute;
-    left: 300px;
-    padding: 50px;
+    width: 100%;
+    height: 100%;
 }
+

--- a/buffalogs/impossible_travel/static/css/all_logins.css
+++ b/buffalogs/impossible_travel/static/css/all_logins.css
@@ -1,9 +1,9 @@
 body{
     background-color: #dee2e6;
 }
+
 #myGrid{
-    width: 80%;
-    position: absolute;
-    left: 300px;
-    padding: 50px;
+    width: 100%;
+    height: 100%;
 }
+

--- a/buffalogs/impossible_travel/static/css/unique_logins.css
+++ b/buffalogs/impossible_travel/static/css/unique_logins.css
@@ -1,9 +1,9 @@
 body{
     background-color: #dee2e6;
 }
+
 #myGrid{
-    width: 80%;
-    position: absolute;
-    left: 300px;
-    padding: 50px;
+    width: 100%;
+    height: 100%;
 }
+

--- a/buffalogs/impossible_travel/templates/impossible_travel/alerts.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/alerts.html
@@ -4,25 +4,28 @@
 {% block title %} Alerts {% endblock %} 
 
 {% block head_content %} 
-
-     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
-     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
-
-     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
-
-     <link rel="stylesheet" href="{% static 'css/alerts.css' %}">
-
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0-alpha1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-GLhlTQ8iRABdZLl6O3oVMWSktQOp6b7In1Zl3/Jr59b6EGGoI1aFkw7cmDA6j6gD" crossorigin="anonymous">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% endblock %} 
 
 {% block body_content %}
-
-
-  <div class="float-container">
-
-    <div id="myGrid" class="ag-theme-alpine-dark"></div>
-    
-  </div>
-
+<div class="p-3 rounded h-100 bg-grey">
+	<div class="container-title d-flex justify-content-between align-items-center text-light bg-grey">
+		<b> User: {{ user.username }} </b>
+		<i class="fa fa-info-circle" aria-hidden="true"></i>
+ 		<div>
+	 		<a href="{% url 'all_logins' pk_user=pk_user %}" class="text-info mr-3 text-decoration-none">All Logins</a>
+        		<a href="{% url 'unique_logins' pk_user=pk_user %}" class="text-info text-decoration-none">Unique Logins</a>
+    		</div>
+	</div>
+	<div class="container-graphic mt-3"> 
+          	<div id="myGrid" class="ag-theme-alpine-dark"></div>
+	</div>
+</div>
 {% endblock %} 
 
 

--- a/buffalogs/impossible_travel/templates/impossible_travel/all_logins.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/all_logins.html
@@ -5,20 +5,28 @@
 
 {% block head_content %} 
 
-    <link rel="stylesheet" href="{% static 'css/homepage.css' %}">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
-    <link rel="stylesheet" href="{% static 'css/all_logins.css' %}"> 
-
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% endblock %} 
 
 {% block body_content %}
+<div class="p-3 rounded h-100 bg-grey">
+	<div class="container-title d-flex justify-content-between align-items-center text-light bg-grey">
+		<b> User: {{ user.username }} </b>
+		<i class="fa fa-info-circle" aria-hidden="true"></i>
+		<div>
+        		<a href="{% url 'alerts' pk_user=pk_user %}" class="text-info text-decoration-none">Alerts</a>
+	 		<a href="{% url 'unique_logins' pk_user=pk_user %}" class="text-info mr-3 text-decoration-none">Unique Logins</a>
+    		</div>
 
-<div class="float-container">
-  
-  <div id="myGrid" class="ag-theme-alpine-dark"></div>
-  
+	</div>
+	<div class="container-graphic mt-3"> 
+          	<div id="myGrid" class="ag-theme-alpine-dark"></div>
+	</div>
 </div>
-
 {% endblock %} 
 
 {% block extend_scripts %} 

--- a/buffalogs/impossible_travel/templates/impossible_travel/unique_logins.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/unique_logins.html
@@ -4,21 +4,28 @@
 {% block title %} All logins {% endblock %} 
 
 {% block head_content %} 
-     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
-     
-    <link rel="stylesheet" href="{% static 'css/unique_logins.css' %}"> 
-
+  <link href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons/font/bootstrap-icons.css" rel="stylesheet">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-grid.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/ag-grid-community@29.3.3/styles/ag-theme-alpine.css">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
 {% endblock %} 
 
 {% block body_content %}
+<div class="p-3 rounded h-100 bg-grey">
+	<div class="container-title d-flex justify-content-between align-items-center text-light bg-grey">
+		<b> User: {{ user.username }} </b>
+		<i class="fa fa-info-circle" aria-hidden="true"></i>
+		<div>
+        		<a href="{% url 'alerts' pk_user=pk_user %}" class="text-info text-decoration-none">Alerts</a>
+	 		<a href="{% url 'all_logins' pk_user=pk_user %}" class="text-info mr-3 text-decoration-none">All Logins</a>
+    		</div>
 
-<div class="float-container">
-  
-  <div id="myGrid" class="ag-theme-alpine-dark"></div>
-  
+	</div>
+	<div class="container-graphic mt-3"> 
+          		<div id="myGrid" class="ag-theme-alpine-dark"></div>
+	</div>
 </div>
-
 {% endblock %} 
 
 {% block extend_scripts %} 

--- a/buffalogs/impossible_travel/views.py
+++ b/buffalogs/impossible_travel/views.py
@@ -25,7 +25,8 @@ def _load_data(name):
 def user_view(template_name):
     def view_decorator(func):
         def wrapper(request, pk_user):
-            context = {"pk_user": pk_user}
+            user = get_object_or_404(User, pk=pk_user)
+            context = {"pk_user": pk_user, "user": user}
             extra_context = func(request, pk_user) if func else {}
             if extra_context:
                 context.update(extra_context)


### PR DESCRIPTION
As noted in #244 , the `all_logins.html`, `alerts.html`, and `unique_logins.html` needed some refinements. I have made the required modification.

## new view

![image](https://github.com/user-attachments/assets/7dd2d14f-8f36-4ece-836f-56fb2c69c80f)


## old view
![image](https://github.com/user-attachments/assets/1a5dd8b7-293d-49ec-9b4e-62f24aa45685)


## Files modified

- `alerts.html`
- 'all_logins.html`
- `unique_logins.html`
- `views.py`

