### PR TITLE
export alert as csv feature added

### DIFF
--- a/buffalogs/buffalogs/urls.py
+++ b/buffalogs/buffalogs/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("users_pie_chart_api/", views.users_pie_chart_api, name="users_pie_chart_api"),
     path("alerts_line_chart_api/", views.alerts_line_chart_api, name="alerts_line_chart_api"),
     path("world_map_chart_api/", views.world_map_chart_api, name="world_map_chart_api"),
+    path("api/export_alerts_csv/", views.export_alerts_csv, name="export_alerts_csv"),
     path("alerts_api/", views.alerts_api, name="alerts_api"),
     path("risk_score_api/", views.risk_score_api, name="risk_score_api"),
     path("authentication/", include("authentication.urls")),

--- a/buffalogs/impossible_travel/static/js/homepage.js
+++ b/buffalogs/impossible_travel/static/js/homepage.js
@@ -166,6 +166,9 @@ document.addEventListener( "DOMContentLoaded", function () {
 
 function cb(start, end) {
     $('#reportrange span').html(start.format('MMMM D, YYYY') + ' - ' + end.format('MMMM D, YYYY'));
+        // Keep CSV-export inputs in sync
+    $('#export-start').val(start.toISOString());
+    $('#export-end').val(end.toISOString());
 }
 
 // Initialize date range picker

--- a/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
@@ -23,6 +23,14 @@
       <i class="fa fa-calendar"></i> 
       <span></span> <i class="fa fa-caret-down"></i>
     </a>
+        <!-- Download CSV button -->
+   <form id="export-csv-form" method="get" action="{% url 'export_alerts_csv' %}" class="d-inline">
+      <input type="hidden" name="start" id="export-start" value="{{startdate}}">
+      <input type="hidden" name="end"   id="export-end"   value="{{enddate}}">
+      <button type="submit" class="btn btn-secondary">
+        <i class="bi bi-download"></i> Download CSV
+      </button>
+    </form>
   </div>
 
   <div class="row">

--- a/buffalogs/impossible_travel/tests/test_views.py
+++ b/buffalogs/impossible_travel/tests/test_views.py
@@ -501,7 +501,7 @@ class TestViews(APITestCase):
             expected_count = details["count"]
             if country_code in data["countries"]:
                 self.assertGreaterEqual(data["countries"][country_code], expected_count, f"Expected at least {expected_count} logins for country {country}")
-                
+
     def test_export_alerts_csv(self):
         """Test the CSV export endpoint returns the correct headers and only intended rows."""
         # Identify our target alerts
@@ -527,18 +527,18 @@ class TestViews(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         # Check headers
-        self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertIn('attachment; filename="alerts.csv"', response['Content-Disposition'])
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn('attachment; filename="alerts.csv"', response["Content-Disposition"])
 
         # Parse CSV
-        lines = response.content.decode('utf-8').splitlines()
-        header = lines[0].split(',')
-        self.assertEqual(header, ['timestamp', 'username', 'alert_name', 'description', 'is_filtered'])
+        lines = response.content.decode("utf-8").splitlines()
+        header = lines[0].split(",")
+        self.assertEqual(header, ["timestamp", "username", "alert_name", "description", "is_filtered"])
 
         # Expect exactly two data rows
         self.assertEqual(len(lines) - 1, 2)
         # Check that our specific timestamps are present in the rows
         rows = lines[1:]
-        vals = [r.split(',')[0] for r in rows]
-        self.assertIn(alert1.login_raw_data['timestamp'], vals)
-        self.assertIn(alert2.login_raw_data['timestamp'], vals)
+        vals = [r.split(",")[0] for r in rows]
+        self.assertIn(alert1.login_raw_data["timestamp"], vals)
+        self.assertIn(alert2.login_raw_data["timestamp"], vals)


### PR DESCRIPTION
- New Backend Endpoint:

1. Added export_alerts_csv view in views.py.
2. Filters alerts by created timestamp within a given start–end ISO8601 range.
3. Returns a downloadable CSV file with fields: timestamp, username, alert_name, description, is_filtered.

- Model Update Check:

Confirmed the Alert model includes a created = models.DateTimeField(auto_now_add=True) field, which is used for filtering.

- New URL Route:

Registered a new path in urls.py:

path("api/export_alerts_csv/", views.export_alerts_csv, name="export_alerts_csv")

- UI Integration (homepage.html):

1. Added a “Download CSV” button to the date range control bar.
2. Button submits the selected date range (start and end) to the export API.

- Date Range Sync (homepage.js):

Ensured date picker updates hidden form fields #export-start and #export-end on user selection.

- Test Coverage:

1. Added a dedicated test case test_export_alerts_csv in testviews.py.
2. Confirms correct CSV headers and row contents for selected alerts within a range.