### PR TITLE
Feat export alerts csv final

### DIFF
--- a/buffalogs/buffalogs/urls.py
+++ b/buffalogs/buffalogs/urls.py
@@ -34,6 +34,7 @@ urlpatterns = [
     path("users_pie_chart_api/", views.users_pie_chart_api, name="users_pie_chart_api"),
     path("alerts_line_chart_api/", views.alerts_line_chart_api, name="alerts_line_chart_api"),
     path("world_map_chart_api/", views.world_map_chart_api, name="world_map_chart_api"),
+    path("api/export_alerts_csv/", views.export_alerts_csv, name="export_alerts_csv"),
     path("alerts_api/", views.alerts_api, name="alerts_api"),
     path("risk_score_api/", views.risk_score_api, name="risk_score_api"),
     path("authentication/", include("authentication.urls")),

--- a/buffalogs/impossible_travel/static/js/homepage.js
+++ b/buffalogs/impossible_travel/static/js/homepage.js
@@ -166,6 +166,9 @@ document.addEventListener( "DOMContentLoaded", function () {
 
 function cb(start, end) {
     $('#reportrange span').html(start.format('MMMM D, YYYY') + ' - ' + end.format('MMMM D, YYYY'));
+        // Keep CSV-export inputs in sync
+    $('#export-start').val(start.toISOString());
+    $('#export-end').val(end.toISOString());
 }
 
 // Initialize date range picker

--- a/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
@@ -20,13 +20,13 @@
   </form>
   <div class="d-flex justify-content-lg-start justify-content-center" id="reportrange" data-startdate="{{startdate}}" data-enddate="{{enddate}}">
     <a href="#" class="btn bg-grey me-2 text-truncate text-light" id="daterange-filter">
-      <i class="fa fa-calendar"></i> 
+      <i class="fa fa-calendar"></i>
       <span></span> <i class="fa fa-caret-down"></i>
     </a>
         <!-- Download CSV button -->
    <form id="export-csv-form" method="get" action="{% url 'export_alerts_csv' %}" class="d-inline">
-      <input type="hidden" name="start" id="export-start" value="{{startdate}}">
-      <input type="hidden" name="end"   id="export-end"   value="{{enddate}}">
+      <input type="hidden" name="start" id="export-start" value="{{ iso_start }}">
+      <input type="hidden" name="end"   id="export-end"   value="{{ iso_end }}">
       <button type="submit" class="btn btn-secondary">
         <i class="bi bi-download"></i> Download CSV
       </button>

--- a/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
+++ b/buffalogs/impossible_travel/templates/impossible_travel/homepage.html
@@ -23,6 +23,14 @@
       <i class="fa fa-calendar"></i> 
       <span></span> <i class="fa fa-caret-down"></i>
     </a>
+        <!-- Download CSV button -->
+   <form id="export-csv-form" method="get" action="{% url 'export_alerts_csv' %}" class="d-inline">
+      <input type="hidden" name="start" id="export-start" value="{{startdate}}">
+      <input type="hidden" name="end"   id="export-end"   value="{{enddate}}">
+      <button type="submit" class="btn btn-secondary">
+        <i class="bi bi-download"></i> Download CSV
+      </button>
+    </form>
   </div>
 
   <div class="row">

--- a/buffalogs/impossible_travel/tests/test_views.py
+++ b/buffalogs/impossible_travel/tests/test_views.py
@@ -501,7 +501,7 @@ class TestViews(APITestCase):
             expected_count = details["count"]
             if country_code in data["countries"]:
                 self.assertGreaterEqual(data["countries"][country_code], expected_count, f"Expected at least {expected_count} logins for country {country}")
-                
+
     def test_export_alerts_csv(self):
         """Test the CSV export endpoint returns the correct headers and only intended rows."""
         # Identify our target alerts
@@ -527,18 +527,18 @@ class TestViews(APITestCase):
         self.assertEqual(response.status_code, 200)
 
         # Check headers
-        self.assertEqual(response['Content-Type'], 'text/csv')
-        self.assertIn('attachment; filename="alerts.csv"', response['Content-Disposition'])
+        self.assertEqual(response["Content-Type"], "text/csv")
+        self.assertIn('attachment; filename="alerts.csv"', response["Content-Disposition"])
 
         # Parse CSV
-        lines = response.content.decode('utf-8').splitlines()
-        header = lines[0].split(',')
-        self.assertEqual(header, ['timestamp', 'username', 'alert_name', 'description', 'is_filtered'])
+        lines = response.content.decode("utf-8").splitlines()
+        header = lines[0].split(",")
+        self.assertEqual(header, ["timestamp", "username", "alert_name", "description", "is_filtered"])
 
         # Expect exactly two data rows
         self.assertEqual(len(lines) - 1, 2)
         # Check that our specific timestamps are present in the rows
         rows = lines[1:]
-        vals = [r.split(',')[0] for r in rows]
-        self.assertIn(alert1.login_raw_data['timestamp'], vals)
-        self.assertIn(alert2.login_raw_data['timestamp'], vals)
+        vals = [r.split(",")[0] for r in rows]
+        self.assertIn(alert1.login_raw_data["timestamp"], vals)
+        self.assertIn(alert2.login_raw_data["timestamp"], vals)

--- a/buffalogs/impossible_travel/views.py
+++ b/buffalogs/impossible_travel/views.py
@@ -1,6 +1,6 @@
+import csv
 import json
 import os
-import csv
 from collections import defaultdict
 from datetime import timedelta
 
@@ -56,13 +56,16 @@ def homepage(request):
     world_map_context = None
     alerts_line_context = None
     if request.method == "GET":
-        date_range = []
         now = timezone.now()
-        end_str = now.strftime("%B %-d, %Y")
+        # human-readable strings for display
         start = now.replace(hour=0, minute=0, second=0, microsecond=0)
         start_str = start.strftime("%B %-d, %Y")
-        date_range.append(start)
-        date_range.append(now)
+        end_str = now.strftime("%B %-d, %Y")
+
+        # ISO strings for machine use (CSV export)
+        iso_start = start.isoformat()
+        iso_end = now.isoformat()
+
         users_pie_context = users_pie_chart(start, now)
         alerts_line_context = alerts_line_chart(start, now)
         world_map_context = world_map_chart(start, now)
@@ -77,17 +80,21 @@ def homepage(request):
         alerts_line_context = alerts_line_chart(start, end)
         world_map_context = world_map_chart(start, end)
 
-    return render(
-        request,
-        "impossible_travel/homepage.html",
-        {
-            "startdate": start_str,
-            "enddate": end_str,
-            "users_pie_context": users_pie_context,
-            "world_map_context": world_map_context,
-            "alerts_line_context": alerts_line_context,
-        },
-    )
+        return render(
+            request,
+            "impossible_travel/homepage.html",
+            {
+                # human-readable
+                "startdate": start_str,
+                "enddate": end_str,
+                # ISO (for the CSV-export hidden inputs)
+                "iso_start": iso_start,
+                "iso_end": iso_end,
+                "users_pie_context": users_pie_context,
+                "world_map_context": world_map_context,
+                "alerts_line_context": alerts_line_context,
+            },
+        )
 
 
 def users(request):
@@ -234,38 +241,53 @@ def users_pie_chart_api(request):
     data = json.dumps(result)
     return HttpResponse(data, content_type="json")
 
-# --- Added: CSV export endpoint
+
 @require_http_methods(["GET"])
 def export_alerts_csv(request):
     """
     Export alerts as CSV for a given ISO8601 start/end window.
     """
-    start = request.GET.get('start')
-    end = request.GET.get('end')
+    start = request.GET.get("start")
+    end = request.GET.get("end")
+
     if not start or not end:
         return HttpResponseBadRequest("Missing 'start' or 'end' parameter")
+
+    # Restore any "+" signs that URL-decoding may have turned into spaces
+    start = start.replace(" ", "+")
+    end = end.replace(" ", "+")
+
     try:
-        start_dt = parse_datetime(start)
-        end_dt = parse_datetime(end)
-        if is_naive(start_dt): start_dt = make_aware(start_dt)
-        if is_naive(end_dt):   end_dt = make_aware(end_dt)
-    except Exception:
+        start_dt = isoparse(start)
+        end_dt = isoparse(end)
+
+        if is_naive(start_dt):
+            start_dt = make_aware(start_dt)
+        if is_naive(end_dt):
+            end_dt = make_aware(end_dt)
+
+    except (ValueError, TypeError):
         return HttpResponseBadRequest("Invalid date format for 'start' or 'end'")
 
     alerts = Alert.objects.filter(created__range=(start_dt, end_dt))
 
-    response = HttpResponse(content_type='text/csv')
-    response['Content-Disposition'] = 'attachment; filename="alerts.csv"'
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="alerts.csv"'
+
     writer = csv.writer(response)
-    writer.writerow(['timestamp', 'username', 'alert_name', 'description', 'is_filtered'])
-    for a in alerts:
-        writer.writerow([
-            a.login_raw_data.get('timestamp'),
-            a.user.username,
-            a.name,
-            a.description,
-            getattr(a, 'is_filtered', False),
-        ])
+    writer.writerow(["timestamp", "username", "alert_name", "description", "is_filtered"])
+
+    for alert in alerts:
+        writer.writerow(
+            [
+                alert.login_raw_data.get("timestamp"),
+                alert.user.username,
+                alert.name,
+                alert.description,
+                getattr(alert, "is_filtered", False),
+            ]
+        )
+
     return response
 
 


### PR DESCRIPTION
- New Backend Endpoint:

1. Added export_alerts_csv view in views.py.
2. Filters alerts by created timestamp within a given start–end ISO8601 range.
3. Returns a downloadable CSV file with fields: timestamp, username, alert_name, description, is_filtered.

- Model Update Check:

Confirmed the Alert model includes a created = models.DateTimeField(auto_now_add=True) field, which is used for filtering.

- New URL Route:

Registered a new path in urls.py:

path("api/export_alerts_csv/", views.export_alerts_csv, name="export_alerts_csv")

- UI Integration (homepage.html):

1. Added a “Download CSV” button to the date range control bar.
2. Button submits the selected date range (start and end) to the export API.

- Date Range Sync (homepage.js):

Ensured date picker updates hidden form fields #export-start and #export-end on user selection.

- Test Coverage:

1. Added a dedicated test case test_export_alerts_csv in testviews.py.
2. Confirms correct CSV headers and row contents for selected alerts within a range.