### PR TITLE
Alert Preferences System

### DIFF
--- a/buffalogs/impossible_travel/tasks.py
+++ b/buffalogs/impossible_travel/tasks.py
@@ -91,5 +91,6 @@ def process_logs(start_date=None, end_date=None):
 
 @shared_task(name="NotifyAlertsTask")
 def notify_alerts():
-    alert = AlertFactory().get_alert_class()
-    alert.notify_alerts()
+    active_alerters = AlertFactory().get_alert_classes()
+    for alerter in active_alerters:
+        alerter.notify_alerts()

--- a/buffalogs/impossible_travel/tests/test_alert_factory.py
+++ b/buffalogs/impossible_travel/tests/test_alert_factory.py
@@ -1,0 +1,25 @@
+from unittest.mock import patch
+
+from django.test import TestCase
+from impossible_travel.alerting.alert_factory import AlertFactory
+from impossible_travel.alerting.base_alerting import BaseAlerting
+
+
+class TestAlertFactory(TestCase):
+    """Test the AlertFactory class."""
+
+    def setUp(self):
+        self.config = {
+            "active_alerters": ["slack", "telegram"],
+            "slack": {"webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"},
+            "telegram": {"bot_token": "BOT_TOKEN", "chat_ids": ["CHAT_ID"]},
+            "discord": {"dummy": "value"},
+        }
+
+    def test_read_config(self):
+        with patch.object(AlertFactory, "_read_config", return_value=self.config):
+            alert_factory = AlertFactory()
+            active_alerters = alert_factory.get_alert_classes()
+            self.assertEqual(len(active_alerters), 2)
+            self.assertIn("SlackAlerting", str(active_alerters[0]))
+            self.assertIn("TelegramAlerting", str(active_alerters[1]))

--- a/config/buffalogs/alerting.json
+++ b/config/buffalogs/alerting.json
@@ -1,5 +1,5 @@
 {
-    "active_alerter": "discord",
+    "active_alerters": ["discord"],
     "slack": {
         "webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"
     },


### PR DESCRIPTION
Resolves #321 

## Changes Made:
- `active_alerter` changed to `active_alerters`
- Users can provide multiple alerters as a list inside the config to receive alerts on multiple sources at once
