### PR TITLE
Added ingestion api enpoint

### DIFF
--- a/buffalogs/buffalogs/urls.py
+++ b/buffalogs/buffalogs/urls.py
@@ -16,7 +16,7 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path
-from impossible_travel.views import alerts, charts, logins, users
+from impossible_travel.views import alerts, charts, ingestion, logins, users
 
 urlpatterns = [
     path("", charts.homepage, name="homepage"),
@@ -44,4 +44,7 @@ urlpatterns = [
     path("authentication/", include("authentication.urls")),
     path("api/export_alerts_csv/", alerts.export_alerts_csv, name="export_alerts_csv"),
     path("api/alert_types/", alerts.alert_types, name="alert_types"),
+    path("api/ingestion/sources/", ingestion.get_ingestion_sources, name="ingestion_sources_api"),
+    path("api/ingestion/active_ingestion_source/", ingestion.get_active_ingestion_source, name="active_ingestion_source_api"),
+    path("api/ingestion/<str:source>/", ingestion.ingestion_source_config, name="ingestion_source_config_api"),
 ]

--- a/buffalogs/impossible_travel/tests/test_ingestion_api_view.py
+++ b/buffalogs/impossible_travel/tests/test_ingestion_api_view.py
@@ -1,0 +1,75 @@
+import json
+from unittest import mock
+
+from django.test import Client
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+
+def mock_write_ingestion_config(source_name, ingestion_config):
+    # do nothing
+    pass
+
+
+class TestIngestionAPIViews(APITestCase):
+
+    def setUp(self):
+        self.client = Client()
+
+    def test_get_ingestion_sources(self):
+        expected = [
+            {"source": "elasticsearch", "fields": ["url", "username", "password", "timeout", "indexes"]},
+            {"source": "opensearch", "fields": ["url", "username", "password", "timeout", "indexes"]},
+            {"source": "splunk", "fields": ["host", "port", "scheme", "username", "password", "timeout", "indexes"]},
+        ]
+        response = self.client.get(f"{reverse('ingestion_sources_api')}")
+        self.assertEqual(response.status_code, 200)
+        self.assertListEqual(expected, json.loads(response.content))
+
+    def test_get_active_ingestion_source(self):
+        expected = {
+            "source": "elasticsearch",
+            "fields": {
+                "url": "http://elasticsearch:9200/",
+                "username": "foobar",
+                "password": "bar",
+                "timeout": 90,
+                "indexes": "cloud-*,fw-proxy-*",
+            },
+        }
+
+        response = self.client.get(f"{reverse('active_ingestion_source_api')}")
+        self.assertEqual(response.status_code, 200)
+        self.assertDictEqual(expected, json.loads(response.content))
+
+    def test_get_unsupported_ingestion_source_config(self):
+        response = self.client.get(f"{reverse('ingestion_source_config_api', kwargs={'source' : 'UNKOWN'})}")
+        expected_error = {"message": "Unsupported ingestion source - UNKOWN"}
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(expected_error, json.loads(response.content))
+
+    def test_get_supported_ingestion_source_config(self):
+        response = self.client.get(f"{reverse('ingestion_source_config_api', kwargs={'source' : 'elasticsearch'})}")
+        expected = {
+            "source": "elasticsearch",
+            "fields": {
+                "url": "http://elasticsearch:9200/",
+                "username": "foobar",
+                "password": "bar",
+                "timeout": 90,
+                "indexes": "cloud-*,fw-proxy-*",
+            },
+        }
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected, json.loads(response.content))
+
+    @mock.patch("impossible_travel.views.ingestion.write_ingestion_config", side_effect=mock_write_ingestion_config)
+    def test_update_ingestion_source_config(self, mock_writer):
+        response = self.client.post(
+            f"{reverse('ingestion_source_config_api', kwargs={'source' : 'elasticsearch'})}",
+            json={"url": "http://new_url", "username": "user2"},
+            content_type="application/json",
+        )
+        expected = {"message": "Update successful"}
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(expected, json.loads(response.content))

--- a/buffalogs/impossible_travel/views/ingestion.py
+++ b/buffalogs/impossible_travel/views/ingestion.py
@@ -1,0 +1,60 @@
+import json
+from pathlib import Path
+
+from django.conf import settings
+from django.http import HttpResponseBadRequest, JsonResponse
+from django.views.decorators.http import require_http_methods
+
+
+def read_config(source_name: str | None = None):
+    config_path = Path(settings.CERTEGO_BUFFALOGS_CONFIG_PATH) / "buffalogs/ingestion.json"
+    with open(config_path, "r", encoding="utf-8") as f:
+        config = json.load(f)
+        if source_name:
+            return config[source_name]
+        return config
+
+
+def write_ingestion_config(source_name: str, ingestion_config: dict[str, str]):
+    config_path = Path(settings.CERTEGO_BUFFALOGS_CONFIG_PATH) / "buffalogs/ingestion.json"
+    config = read_config()
+    config[source_name] = ingestion_config
+    with open(config_path, "w", encoding="utf-8") as f:
+        json.dump(f, config, indent=2)
+
+
+@require_http_methods(["GET"])
+def get_ingestion_sources(request):
+    config = read_config()
+    active_ingestion = config.pop("active_ingestion")
+    ingestors = [{"source": ingestor, "fields": config[ingestor]["__custom_fields__"]} for ingestor in config.keys()]
+    return JsonResponse(ingestors, json_dumps_params={"default": str}, safe=False)
+
+
+@require_http_methods(["GET"])
+def get_active_ingestion_source(request):
+    config = read_config()
+    source = config["active_ingestion"]
+    context = {"source": source, "fields": dict((field, config[source][field]) for field in config[source]["__custom_fields__"])}
+    return JsonResponse(context, json_dumps_params={"default": str})
+
+
+def ingestion_source_config(request, source):
+    try:
+        ingestion_config = read_config(source)
+    except KeyError:
+        return JsonResponse({"message": f"Unsupported ingestion source - {source}"}, status=400)
+
+    if request.method == "GET":
+        context = {"source": source, "fields": dict((field, ingestion_config[field]) for field in ingestion_config["__custom_fields__"])}
+        return JsonResponse(context, json_dumps_params={"default": str})
+
+    if request.method == "POST":
+        config_update = json.loads(request.body.decode("utf-8"))
+        error_fields = [field for field in config_update.keys() if field not in ingestion_config["__custom_fields__"]]
+        if any(error_fields):
+            return JsonResponse({"message": f"Unexpected configuration fields - {error_fields}"}, status=400)
+        else:
+            ingestion_config.update(config_update)
+            write_ingestion_config(source, ingestion_config)
+            return JsonResponse({"message": "Update successful"}, status=200)

--- a/config/buffalogs/ingestion.json
+++ b/config/buffalogs/ingestion.json
@@ -18,7 +18,8 @@
             "source.geo.country_name": "country",
             "source.geo.location.lat": "lat",
             "source.geo.location.lon": "lon"
-        }
+        },
+	"__custom_fields__" : ["url", "username", "password", "timeout", "indexes"]
     },
     "opensearch": {
         "url": "http://opensearch:9200/",
@@ -38,7 +39,8 @@
             "source.geo.country_name": "country",
             "source.geo.location.lat": "lat",
             "source.geo.location.lon": "lon"
-        }
+        },
+	"__custom_fields__" : ["url", "username", "password", "timeout", "indexes"]
     },
     "splunk": {
         "host": "splunk",
@@ -60,6 +62,7 @@
             "source.as.organization.name": "organization",
             "_id": "id",
             "index": "index"
-        }
+        },
+	"__custom_fields__" : ["host","port", "scheme", "username", "password", "timeout", "indexes"]
       }
 }


### PR DESCRIPTION
In reference to issue #323 

Created new ingestion API endpoints that let users view and configure log ingestion.

The configuration mechanism uses a `__custom_field__` key added to each ingestion configuration to determine which field value pair can be edited by the user