### PR TITLE
Remove `test_send_actual_alert` from alerter tests

### DIFF
--- a/buffalogs/impossible_travel/tests/alerters/test_alert_discord.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_discord.py
@@ -65,19 +65,3 @@ class TestDiscordAlerting(TestCase):
         """Test that an error is raised if the configuration is not correct"""
         with self.assertRaises(ValueError):
             DiscordAlerting({})
-
-    @patch("requests.post")
-    def test_alert_network_failure(self, mock_post):
-        """Test that alert is not marked as notified if there are any Network Fails"""
-        # Simulate network/API failure
-        mock_post.side_effect = requests.RequestException()
-
-        self.discord_alerting.notify_alerts()
-
-        # Reload the alert from DB to check its state
-        alert = Alert.objects.get(pk=self.alert.pk)
-        self.assertFalse(alert.notified_status["discord"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.discord_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_discord.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_discord.py
@@ -65,3 +65,15 @@ class TestDiscordAlerting(TestCase):
         """Test that an error is raised if the configuration is not correct"""
         with self.assertRaises(ValueError):
             DiscordAlerting({})
+
+    @patch("requests.post")
+    def test_alert_network_failure(self, mock_post):
+        """Test that alert is not marked as notified if there are any Network Fails"""
+        # Simulate network/API failure
+        mock_post.side_effect = requests.RequestException()
+
+        self.discord_alerting.notify_alerts()
+
+        # Reload the alert from DB to check its state
+        alert = Alert.objects.get(pk=self.alert.pk)
+        self.assertFalse(alert.notified_status["discord"])

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_email.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_email.py
@@ -65,7 +65,3 @@ class TestEmailAlerting(TestCase):
         """Test that an error is raised if the configuration is not correct"""
         with self.assertRaises(ValueError):
             EmailAlerting({})
-
-    def test_send_email(self):
-        """Actually sending the email to the recepient's address."""
-        self.email_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_googlechat.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_googlechat.py
@@ -73,7 +73,3 @@ class TestGoogleChatAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["googlechat"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.googlechat_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_mattermost.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_mattermost.py
@@ -70,7 +70,3 @@ class TestMattermostAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["mattermost"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.mattermost_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_microsoft_teams.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_microsoft_teams.py
@@ -74,7 +74,3 @@ class TestMicrosoftTeamsAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["microsoftteams"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.teams_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_pushover.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_pushover.py
@@ -64,7 +64,3 @@ class TestPushoverAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["pushover"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.pushover_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_rocketchat.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_rocketchat.py
@@ -70,7 +70,3 @@ class TestRocketChatAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["rocketchat"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.rocketchat_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_slack.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_slack.py
@@ -74,7 +74,3 @@ class TestSlackAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["slack"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.slack_alerting.notify_alerts()

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_telegram.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_telegram.py
@@ -80,7 +80,3 @@ class TestTelegramAlerting(TestCase):
         # Reload the alert from DB to check its state
         alert = Alert.objects.get(pk=self.alert.pk)
         self.assertFalse(alert.notified_status["telegram"])
-
-    def test_send_actual_alert(self):
-        """Test sending an actual alert"""
-        self.telegram_alerting.notify_alerts()


### PR DESCRIPTION
Resolves #376 

## Changes made
- Removes `test_send_actual_alert` from all the alerter tests
- This fixes the timeout errors received from backoff mechanism while sending actual alerts