### PR TITLE
Refactor(tests): improve Testalerter performance using setUpTestData

### DIFF
--- a/buffalogs/impossible_travel/tests/alerters/test_alert_factory.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_factory.py
@@ -10,22 +10,21 @@ from impossible_travel.models import Alert, Login, User
 class TestAlertFactory(TestCase):
     """Test the AlertFactory class."""
 
-    def setUp(self):
-        self.config = {
+    @classmethod
+    def setUpTestData(cls):
+        cls.config = {
             "active_alerters": ["slack", "telegram"],
             "telegram": {"bot_token": "BOT_TOKEN", "chat_ids": ["CHAT_ID"]},
             "slack": {"webhook_url": "WEBHOOK_URL"},
             "discord": {"dummy": "dummy"},
         }
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create an alert
-        self.alert = Alert.objects.create(
+        cls.alert = Alert.objects.create(
             name="Imp Travel",
-            user=self.user,
+            user=cls.user,
             notified_status={"telegram": False, "slack": False, "discord": False},
             description="Impossible travel detected",
             login_raw_data={},

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_googlechat.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_googlechat.py
@@ -8,19 +8,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestGoogleChatAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.googlechat_config = BaseAlerting.read_config("googlechat")
+        cls.googlechat_alerting = GoogleChatAlerting(cls.googlechat_config)
 
-        self.googlechat_config = BaseAlerting.read_config("googlechat")
-        self.googlechat_alerting = GoogleChatAlerting(self.googlechat_config)
+        # Shared user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"googlechat": False}, description="Impossible travel detected", login_raw_data={}
+        # Shared alert
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"googlechat": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_mattermost.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_mattermost.py
@@ -8,19 +8,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestMattermostAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.mattermost_config = BaseAlerting.read_config("mattermost")
+        cls.mattermost_alerting = MattermostAlerting(cls.mattermost_config)
 
-        self.mattermost_config = BaseAlerting.read_config("mattermost")
-        self.mattermost_alerting = MattermostAlerting(self.mattermost_config)
+        # Create shared user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"mattermost": False}, description="Impossible travel detected", login_raw_data={}
+        # Create shared alert
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"mattermost": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_microsoft_teams.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_microsoft_teams.py
@@ -9,19 +9,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestMicrosoftTeamsAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.teams_config = BaseAlerting.read_config("microsoftteams")
+        cls.teams_alerting = MicrosoftTeamsAlerting(cls.teams_config)
 
-        self.teams_config = BaseAlerting.read_config("microsoftteams")
-        self.teams_alerting = MicrosoftTeamsAlerting(self.teams_config)
+        # Create shared user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"microsoftteams": False}, description="Impossible travel detected", login_raw_data={}
+        # Create shared alert
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"microsoftteams": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_pushover.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_pushover.py
@@ -9,19 +9,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestPushoverAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.pushover_config = BaseAlerting.read_config("pushover")
+        cls.pushover_alerting = PushoverAlerting(cls.pushover_config)
 
-        self.pushover_config = BaseAlerting.read_config("pushover")
-        self.pushover_alerting = PushoverAlerting(self.pushover_config)
+        # Create shared user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"pushover": False}, description="Impossible travel detected", login_raw_data={}
+        # Create shared alert
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"pushover": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_rocketchat.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_rocketchat.py
@@ -8,19 +8,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestRocketChatAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.rocketchat_config = BaseAlerting.read_config("rocketchat")
+        cls.rocketchat_alerting = RocketChatAlerting(cls.rocketchat_config)
 
-        self.rocketchat_config = BaseAlerting.read_config("rocketchat")
-        self.rocketchat_alerting = RocketChatAlerting(self.rocketchat_config)
+        # Shared test user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"rocketchat": False}, description="Impossible travel detected", login_raw_data={}
+        # Alert shared across test cases
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"rocketchat": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")

--- a/buffalogs/impossible_travel/tests/alerters/test_alert_slack.py
+++ b/buffalogs/impossible_travel/tests/alerters/test_alert_slack.py
@@ -8,19 +8,19 @@ from impossible_travel.models import Alert, Login, User
 
 
 class TestSlackAlerting(TestCase):
-    def setUp(self):
-        """Set up test data before running tests."""
+    @classmethod
+    def setUpTestData(cls):
+        """Set up test data once for all tests in this class."""
+        cls.slack_config = BaseAlerting.read_config("slack")
+        cls.slack_alerting = SlackAlerting(cls.slack_config)
 
-        self.slack_config = BaseAlerting.read_config("slack")
-        self.slack_alerting = SlackAlerting(self.slack_config)
+        # Create shared test user and login
+        cls.user = User.objects.create(username="testuser")
+        Login.objects.create(user=cls.user, id=cls.user.id)
 
-        # Create a dummy user
-        self.user = User.objects.create(username="testuser")
-        Login.objects.create(user=self.user, id=self.user.id)
-
-        # Create an alert
-        self.alert = Alert.objects.create(
-            name="Imp Travel", user=self.user, notified_status={"slack": False}, description="Impossible travel detected", login_raw_data={}
+        # Create alert
+        cls.alert = Alert.objects.create(
+            name="Imp Travel", user=cls.user, notified_status={"slack": False}, description="Impossible travel detected", login_raw_data={}
         )
 
     @patch("requests.post")


### PR DESCRIPTION
reference : #365

Replaced setUp with setUpTestData to avoid redundant DB operations across tests. This reduces test execution time and improves readability.