### PR TITLE
Fix alerts view read config

### DIFF
--- a/buffalogs/impossible_travel/tests/api/test_alerts_api.py
+++ b/buffalogs/impossible_travel/tests/api/test_alerts_api.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from rest_framework.test import APITestCase
 
 
-def mock_read_config(key: str | None = None):
+def mock_read_config(filename: str, key: str | None = None):
     config = {
         "active_alerters": ["discord"],
         "slack": {"webhook_url": "https://hooks.slack.com/services/YOUR/WEBHOOK/URL"},
@@ -35,7 +35,7 @@ def mock_read_config(key: str | None = None):
     return config
 
 
-def mock_write_config(key: str, updates: dict[str, str]):
+def mock_write_config(filename: str, key: str, updates: dict[str, str]):
     pass
 
 

--- a/buffalogs/impossible_travel/views/alerts.py
+++ b/buffalogs/impossible_travel/views/alerts.py
@@ -8,7 +8,7 @@ from django.utils.timezone import is_naive, make_aware
 from django.views.decorators.http import require_http_methods
 from impossible_travel.constants import AlertDetectionType
 from impossible_travel.models import Alert, User
-from impossible_travel.views.utils import get_config_read_write, read_config, write_config
+from impossible_travel.views.utils import read_config, write_config
 
 
 @require_http_methods(["GET"])

--- a/buffalogs/impossible_travel/views/alerts.py
+++ b/buffalogs/impossible_travel/views/alerts.py
@@ -8,9 +8,7 @@ from django.utils.timezone import is_naive, make_aware
 from django.views.decorators.http import require_http_methods
 from impossible_travel.constants import AlertDetectionType
 from impossible_travel.models import Alert, User
-from impossible_travel.views.utils import get_config_read_write
-
-read_config, write_config = get_config_read_write("alerting.json")
+from impossible_travel.views.utils import get_config_read_write, read_config, write_config
 
 
 @require_http_methods(["GET"])
@@ -139,7 +137,7 @@ def serialize_config(config_dict):
 
 @require_http_methods(["GET"])
 def get_alerters(request):
-    config = read_config()
+    config = read_config("alerting.json")
     config.pop("active_alerters")
     alerters = [
         {"alerter": alerter, "fields": [field for field in config[alerter].keys() if field != "options"], "options": list(config[alerter].get("options", []))}
@@ -151,7 +149,7 @@ def get_alerters(request):
 
 @require_http_methods(["GET"])
 def get_active_alerter(request):
-    alert_config = read_config()
+    alert_config = read_config("alerting.json")
     active_alerters = alert_config["active_alerters"]
     alerter_config = [{"alerter": alerter, "fields": alert_config[alerter]} for alerter in active_alerters]
     return JsonResponse(alerter_config, safe=False, json_dumps_params={"default": str})
@@ -159,7 +157,7 @@ def get_active_alerter(request):
 
 def alerter_config(request, alerter):
     try:
-        alerter_config = read_config(key=alerter)
+        alerter_config = read_config("alerting.json", key=alerter)
     except KeyError:
         return JsonResponse({"message": f"Unsupported alerter - {alerter}"}, status=400)
 
@@ -174,5 +172,5 @@ def alerter_config(request, alerter):
             return JsonResponse({"message": f"Unexpected configuration fields - {error_fields}"}, status=400)
         else:
             alerter_config.update(config_update)
-            write_config(alerter, alerter_config)
+            write_config("alerting.json", alerter, alerter_config)
             return JsonResponse({"message": "Update successful"}, status=200)


### PR DESCRIPTION
In respect to #390 

The error was due to `read_config` being a partial function with a pre-configured `filename` argument.

**Fix**
<img width="1279" height="650" alt="image" src="https://github.com/user-attachments/assets/f9161024-f3c4-4337-b2ab-1d338756eb93" />
