### PR TITLE
Club similar alerts together

### DIFF
--- a/buffalogs/impossible_travel/alerting/base_alerting.py
+++ b/buffalogs/impossible_travel/alerting/base_alerting.py
@@ -50,12 +50,12 @@ class BaseAlerting(ABC):
         return config.get(alerter_key, {})
 
     @staticmethod
-    def alert_message_formatter(alert, template_path="alert_template.jinja"):
+    def alert_message_formatter(alert, template_path="alert_template.jinja", *args, **kwargs):
         """
         Format the alert message for notification.
         """
         env = Environment(loader=FileSystemLoader(os.path.join(settings.CERTEGO_BUFFALOGS_CONFIG_PATH, "buffalogs/")))
         template = env.get_template(template_path)
-        alert_title = template.module.title(alert)
-        alert_description = template.module.description(alert)
+        alert_title = template.module.title(alert, **kwargs)
+        alert_description = template.module.description(alert, **kwargs)
         return alert_title, alert_description

--- a/buffalogs/impossible_travel/alerting/slack_alerting.py
+++ b/buffalogs/impossible_travel/alerting/slack_alerting.py
@@ -2,8 +2,12 @@ try:
     import requests
 except ImportError:
     pass
+from collections import defaultdict
+from datetime import timedelta
+
 import backoff
 from django.db.models import Q
+from django.utils import timezone
 from impossible_travel.alerting.base_alerting import BaseAlerting
 from impossible_travel.models import Alert
 
@@ -49,10 +53,38 @@ class SlackAlerting(BaseAlerting):
         """
         Execute the alerter operation.
         """
-        alerts = Alert.objects.filter(Q(notified_status__slack=False) | ~Q(notified_status__has_key="slack"))
+        time_threshold = timezone.now() - timedelta(minutes=5)
+        alerts = Alert.objects.filter((Q(notified_status__slack=False) | ~Q(notified_status__has_key="slack")) & Q(created__gte=time_threshold))
 
+        grouped = defaultdict(list)
         for alert in alerts:
+            key = (alert.user.username, alert.name)
+            grouped[key].append(alert)
+
+        for (username, alert_name), group_alerts in grouped.items():
             try:
-                self.send_message(alert)
+                if len(group_alerts) == 1:
+                    self.send_message(group_alerts[0])
+                else:
+                    alert = group_alerts[0]
+                    alert_title, alert_description = self.alert_message_formatter(
+                        alert=alert, template_path="alert_template_clubbed.jinja", alerts=group_alerts
+                    )
+                    alert_msg = {
+                        "attachments": [
+                            {
+                                "title": alert_title,
+                                "text": alert_description,
+                                "color": "#ff0000",
+                            }
+                        ]
+                    }
+                    resp = requests.post(self.webhook_url, json=alert_msg, headers={"Content-Type": "application/json"})
+                    resp.raise_for_status()
+                    self.logger.info(f"Clubbed Slack alert sent: {alert_title}")
+
+                    for a in group_alerts:
+                        a.notified_status["slack"] = True
+                        a.save()
             except requests.RequestException as e:
                 self.logger.exception(f"Slack alert failed for {alert.name}: {str(e)}")

--- a/config/buffalogs/alert_template_clubbed.jinja
+++ b/config/buffalogs/alert_template_clubbed.jinja
@@ -1,0 +1,16 @@
+{% macro title(alert,alerts) -%}
+BuffaLogs - Login Anomaly Alerts : {{ alerts|length }} "{{ alert.name }}" alerts for user {{ alert.user.username }}
+{%- endmacro %}
+
+{% macro description(alert,alerts) -%}
+Dear admin,
+
+{{ alerts|length }} similar "{{ alert.name }}" alerts detected for user {{ alert.user.username }} in the last 5 minutes:
+
+{% for alert in alerts %}
+- {{ alert.login_raw_data.timestamp if alert.login_raw_data.timestamp is defined else alert.created }}: {{ alert.description }}
+{% endfor %}
+
+Stay Safe,  
+BuffaLogs
+{%- endmacro %}


### PR DESCRIPTION
Resolves #401 

## Changes made:
- `alert_message_formatter` can now take arbitary arguments to forward to jinja templates
- Logic added to get the most recent alerts(<=5 mins) and alert them together in a single message.
- New jinja template `config/buffalogs/alert_template_clubbed.jinja` added
- New test `test_clubbed_alerts` added to test the newly added logic