### PR TITLE
Fix frontend login ERR_CONNECTION_REFUSED by exposing backend on port 8000

### DIFF
--- a/buffalogs/requirements.txt
+++ b/buffalogs/requirements.txt
@@ -37,3 +37,7 @@ Jinja2>=3.1.6                   # Templating engine for rendering alert messages
 
 # === Backoff ===
 backoff>=2.2.1                   # Library for retrying operations with exponential backoff
+
+# === Web Server ===
+
+uwsgi>=2.0.21 # uWSGI application server for serving Django application

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,6 +32,7 @@ services:
             - buffalogs_nginx_logs:/var/log/nginx:rw
         ports:
             - "80:80"
+            - "8000:80"
            # - "443:443"
 
     buffalogs:


### PR DESCRIPTION

This PR resolves the issue where login submissions from the nextjs frontend returned an `ERR_CONNECTION_REFUSED` error. The root cause was that the frontend was configured to send authentication requests to `http://localhost:8000`, but the backend (Django via Nginx) was only exposed on port 80 in Docker Compose.

**Changes made:**
- Updated docker-compose.yaml to expose Nginx on port 8000 (`"8000:80"`), allowing frontend requests to `localhost:8000` to be routed correctly to the backend.
- No changes to frontend code, as the base URL in constants.ts already points to `http://localhost:8000`.

**How to test:**
1. ```bash
    docker compose up -d
    ```
2. create a super user
```bash
docker-compose exec buffalogs python manage.py shell -c "
from authentication.models import User
user = User.objects.create_superuser(username='admin', email='admin@example.com', password='admin123')
print(f'Superuser created: {user.username}')
"
```
4. Browse to [http://localhost:3000](http://localhost:3000).
5. Submit login credentials; authentication should now work without connection errors.

---

Closes #292 