### PR TITLE
Refactor Api testcases

### DIFF
--- a/buffalogs/impossible_travel/tests/api/test_ingestion_api.py
+++ b/buffalogs/impossible_travel/tests/api/test_ingestion_api.py
@@ -1,7 +1,6 @@
 import json
 from unittest import mock
 
-from django.test import Client
 from django.urls import reverse
 from rest_framework.test import APITestCase
 
@@ -12,17 +11,13 @@ def mock_write_ingestion_config(source_name, ingestion_config):
 
 
 class TestIngestionAPIViews(APITestCase):
-
-    def setUp(self):
-        self.client = Client()
-
     def test_get_ingestion_sources(self):
         expected = [
             {"source": "elasticsearch", "fields": ["url", "username", "password", "timeout", "indexes"]},
             {"source": "opensearch", "fields": ["url", "username", "password", "timeout", "indexes"]},
             {"source": "splunk", "fields": ["host", "port", "scheme", "username", "password", "timeout", "indexes"]},
         ]
-        response = self.client.get(f"{reverse('ingestion_sources_api')}")
+        response = self.client.get(reverse("ingestion_sources_api"))
         self.assertEqual(response.status_code, 200)
         self.assertListEqual(expected, json.loads(response.content))
 
@@ -37,19 +32,17 @@ class TestIngestionAPIViews(APITestCase):
                 "indexes": "cloud-*,fw-proxy-*",
             },
         }
-
-        response = self.client.get(f"{reverse('active_ingestion_source_api')}")
+        response = self.client.get(reverse("active_ingestion_source_api"))
         self.assertEqual(response.status_code, 200)
         self.assertDictEqual(expected, json.loads(response.content))
 
     def test_get_unsupported_ingestion_source_config(self):
-        response = self.client.get(f"{reverse('ingestion_source_config_api', kwargs={'source' : 'UNKOWN'})}")
+        response = self.client.get(reverse("ingestion_source_config_api", kwargs={"source": "UNKOWN"}))
         expected_error = {"message": "Unsupported ingestion source - UNKOWN"}
         self.assertEqual(response.status_code, 400)
         self.assertEqual(expected_error, json.loads(response.content))
 
     def test_get_supported_ingestion_source_config(self):
-        response = self.client.get(f"{reverse('ingestion_source_config_api', kwargs={'source' : 'elasticsearch'})}")
         expected = {
             "source": "elasticsearch",
             "fields": {
@@ -60,15 +53,16 @@ class TestIngestionAPIViews(APITestCase):
                 "indexes": "cloud-*,fw-proxy-*",
             },
         }
+        response = self.client.get(reverse("ingestion_source_config_api", kwargs={"source": "elasticsearch"}))
         self.assertEqual(response.status_code, 200)
         self.assertEqual(expected, json.loads(response.content))
 
     @mock.patch("impossible_travel.views.ingestion.write_config", side_effect=mock_write_ingestion_config)
     def test_update_ingestion_source_config(self, mock_writer):
         response = self.client.post(
-            f"{reverse('ingestion_source_config_api', kwargs={'source' : 'elasticsearch'})}",
-            json={"url": "http://new_url", "username": "user2"},
-            content_type="application/json",
+            reverse("ingestion_source_config_api", kwargs={"source": "elasticsearch"}),
+            {"url": "http://new_url", "username": "user2"},
+            format="json",
         )
         expected = {"message": "Update successful"}
         self.assertEqual(response.status_code, 200)


### PR DESCRIPTION

**Ref: #366**

In this PR, we improve the test case by removing the custom `setUp` method, which is unnecessary when using `APITestCase`. Since `APITestCase` already provides `self.client` as an instance of DRF’s which fully support JSON requests via `format="json"` manually instantiating `self.client = Client()` is redundant and may potentially impact test performance.
