### PR TITLE
Add requests library for HTTP operations in requirements

### DIFF
--- a/buffalogs/requirements.txt
+++ b/buffalogs/requirements.txt
@@ -38,6 +38,8 @@ Jinja2>=3.1.6                   # Templating engine for rendering alert messages
 # === Backoff ===
 backoff>=2.2.1                   # Library for retrying operations with exponential backoff
 
-# === Web Server ===
+# === HTTP Requests ===
+requests>=2.31.0                  # HTTP library for sending alerts and webhooks
 
+# === Web Server ===
 uwsgi>=2.0.21 # uWSGI application server for serving Django application


### PR DESCRIPTION
The Celery worker and beat containers failed to start due to a NameError referencing requests in alerting modules when requests was not installed.
This PR adds `requests` to `requirements.txt` so the module is available in the container image and Celery can start correctly.

### Changes:
- Add requests>=2.31.0 to `requirements.txt`
<img width="1920" height="1080" alt="Screenshot_16-Aug_12-43-07_32104" src="https://github.com/user-attachments/assets/5698c072-18a5-4183-9b08-8c83c4e3372c" />


closes #406 