### PR TITLE
prevent Worldmap crash on empty data and ensure map renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ venv/
 dist/
 **/.DS_Store
 *.egg-info/
+/node_modules

--- a/frontend/components/Worldmap.tsx
+++ b/frontend/components/Worldmap.tsx
@@ -18,7 +18,7 @@ interface Country {
 }
 
 const geoUrl =
-  "https://raw.githubusercontent.com/deldersveld/topojson/master/world-continents.json";
+  "https://raw.githubusercontent.com/holtzy/D3-graph-gallery/master/DATA/world.geojson";
 
 const MapChart = () => {
   const [data, setData] = useState<Country[]>([]);
@@ -28,30 +28,49 @@ const MapChart = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const data: Country[] = await getWorldMapChart(date);
-      setData(data);
-      let maxAlerts = data[0].alerts;
-      for (const country of data) {
-        if (country.alerts > maxAlerts) {
-          maxAlerts = country.alerts;
+      try {
+        const result: Country[] = await getWorldMapChart(date);
+        setData(result);
+        
+        if (result.length > 0) {
+          const maxAlerts = Math.max(...result.map(country => country.alerts));
+          setMaxValue(maxAlerts);
+        } else {
+          setMaxValue(0);
         }
+      } catch (err) {
+        setData([]);
+        setMaxValue(0);
       }
-      setMaxValue(maxAlerts);
     };
-    fetchData();
+    
+    if (date) {
+      fetchData();
+    } else {
+      setData([]);
+      setMaxValue(0);
+    }
   }, [date]);
 
   const popScale = useMemo(
-    () => scaleLinear().domain([0, maxValue]).range([0, 18]),
+    () => scaleLinear().domain([0, maxValue]).range([0, 12]),
     [maxValue]
   );
 
   return (
-    <div className="">
-      <ComposableMap projectionConfig={{ rotate: [-10, 0, 0] }}>
+    <div className="w-full h-96">
+      <ComposableMap
+        projectionConfig={{
+          rotate: [-10, 0, 0],
+          scale: 147
+        }}
+        width={800}
+        height={384}
+        style={{ width: "100%", height: "100%" }}
+      >
         <ZoomableGroup
           center={[0, 0]}
-          zoom={1}
+          zoom={zoom}
           maxZoom={6}
           onMoveEnd={({ coordinates, zoom }) => {
             setZoom(zoom);
@@ -60,21 +79,26 @@ const MapChart = () => {
           <Geographies geography={geoUrl}>
             {({ geographies }) =>
               geographies.map((geo) => (
-                <Geography key={geo.rsmKey} geography={geo} fill="#5B5C60" />
+                <Geography 
+                  key={geo.rsmKey} 
+                  geography={geo} 
+                  fill="#5B5C60" 
+                  stroke="#FFFFFF"
+                  strokeWidth={0.5}
+                />
               ))
             }
           </Geographies>
-          {data.map(({ country, lat, lon, alerts }) => {
-            return (
-              <Marker key={country} coordinates={[lon, lat]}>
-                <circle
-                  fill="#F53"
-                  stroke="#FFF"
-                  r={popScale(alerts)/zoom}
-                />
-              </Marker>
-            );
-          })}
+          {data.map(({ country, lat, lon, alerts }) => (
+            <Marker key={country} coordinates={[lon, lat]}>
+              <circle
+                fill="#F53"
+                stroke="#FFF"
+                strokeWidth={2}
+                r={Math.max(2, popScale(alerts) / zoom)}
+              />
+            </Marker>
+          ))}
         </ZoomableGroup>
       </ComposableMap>
     </div>


### PR DESCRIPTION
###  Fixes
- Fixes frontend crash when `/api/impossible_travel/worldmap/` returns an empty array (TypeError: can't access property "alerts", data[0] is undefined).
- Ensures world map always renders (even when API/backend is down or returns no alerts).
- Adds safe max calculation, graceful error handling, and keeps map interactive.
- Restores original darker color scheme and reduces marker sizes for better UX.

### Files changed:
- Worldmap.tsx
  - Validate API result length before accessing elements.
  - Use Math.max(...) for max alerts.
  - Always render the map (no early returns); handle API failures by using empty data.
  - Use reliable `GeoJSON URL` for rendering instade old  `TopJSON`.
  - Reduce marker sizing range from [0,18] to [0,12] and keep min radius 2. (i just felt old dots were little big)

### UI impact
<img width="1920" height="1080" alt="Screenshot_22-Aug_14-14-10_17181" src="https://github.com/user-attachments/assets/502acef1-58a2-41f1-abc0-9f8291f3897c" />

---

Now the map is rendering without the need for api data 
closes #417 