### PR TITLE
Fix worldmap markers not appearing for test alerts ( update DateContext default date range)

### DIFF
--- a/frontend/contexts/DateContext.tsx
+++ b/frontend/contexts/DateContext.tsx
@@ -14,9 +14,12 @@ interface DateContextProviderProps {
 }
 
 export const DateContextProvider: React.FC<DateContextProviderProps> = ({ children }) => {
-  const [date, setDate] = useState<DateRange | undefined>({
-    from: new Date(2023, 6, 20),
-    to: addDays(new Date(2023, 7, 1), 20),
+  const [date, setDate] = useState<DateRange | undefined>(() => {
+    const today = new Date();
+    return {
+      from: addDays(today, -7),
+      to: today,
+    };
   });
 
   return (


### PR DESCRIPTION
The worldmap on the dashboard did not render red markers for test alerts created with 2025 timestamps. The frontend `DateContext` had a hard-coded default range (July–August 2023), so the frontend never queried a date range that included the test data. I updated the default date range behavior so the worldmap queries ranges that include current/test alert timestamps.


## What I changed (fix)
- Updated the frontend `DateContext` default behavior so the initial date range is not stuck on July–August 2023 and instead uses a dynamic/current-relative default (so the frontend queries ranges that include recent/test alert timestamps).
- Files changed:
  - DateContext.tsx — updated default date range logic.

## Result
<img width="1827" height="586" alt="image" src="https://github.com/user-attachments/assets/058b9622-b3ae-490f-8c59-f9a76550219e" />

closes #426 
