### PR TITLE
Fixed sed command in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR $INSTALL_PATH
 COPY buffalogs/requirements.txt requirements.txt
 
 
-RUN sed -i 's/main/main non-free/g' /etc/apt/sources.list \
+RUN sed -i 's/main/main non-free/g' /etc/apt/sources.list.d/debian.sources \
     && apt-get update \
     && apt-get -y install \
         gcc


### PR DESCRIPTION
 Fixed sed command in Dockerfile that updated /etc/apt/sources.list, preventing Docker build failure with exit code 2