### PR TITLE
fix(dockerfile):fixed the docker file for the frontend

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-slim
+FROM node:lts-alpine
 
 WORKDIR /app
 


### PR DESCRIPTION
Since i gone through the issue i found that `node:lts-slim` which is Debian-based, not Alpine-based therfore apk (the Alpine package manager) doesn’t exist in that image.
So  the `lts-aplne `is usded instead of `lts-slim` .
