### PR TITLE
fix: connect networks using buffalogs-network

### DIFF
--- a/docker-compose.elastic.yaml
+++ b/docker-compose.elastic.yaml
@@ -22,6 +22,7 @@ services:
             - elasticsearch_data:/usr/share/elasticsearch/data
         networks:
             - elk
+            - buffalogs_network 
         healthcheck:
             test: curl -XGET 'localhost:9200/_cluster/health?wait_for_status=yellow&timeout=180s&pretty'
 
@@ -34,6 +35,7 @@ services:
             ELASTICSEARCH_HOSTS: http://elasticsearch:9200
         networks:
             - elk
+            - buffalogs_network
         depends_on:
             - buffalogs_elasticsearch
         ports:
@@ -48,3 +50,5 @@ volumes:
 networks:
     elk:
         driver: bridge
+    buffalogs_network:
+        external: true

--- a/docker-compose.opensearch.yaml
+++ b/docker-compose.opensearch.yaml
@@ -24,6 +24,7 @@ services:
             - opensearch_data:/usr/share/opensearch/data
         networks:
             - opensearch-net
+            - buffalogs_network
 
     opensearch-dashboards:
         container_name: buffalogs_opensearch-dashboards
@@ -36,6 +37,7 @@ services:
             - "127.0.0.1:5601:5601"
         networks:
             - opensearch-net
+            - buffalogs_network
 
 volumes:
     opensearch_data:
@@ -44,3 +46,5 @@ volumes:
 networks:
     opensearch-net:
         driver: bridge
+    buffalogs_network:
+        external: true

--- a/docker-compose.splunk.yaml
+++ b/docker-compose.splunk.yaml
@@ -20,6 +20,7 @@ services:
             - splunk_etc:/opt/splunk/etc
         networks:
             - splunk-net
+            - buffalogs_network
         restart: unless-stopped
 
 volumes:
@@ -31,3 +32,5 @@ volumes:
 networks:
     splunk-net:
         driver: bridge
+    buffalogs_network:
+        external: true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,8 @@ services:
         container_name: buffalogs_postgres
         image: postgres:15-alpine
         hostname: postgres
+        networks:
+            - buffalogs_network
         environment:
             POSTGRES_USER: default_user
             POSTGRES_PASSWORD: password
@@ -22,6 +24,8 @@ services:
         container_name: buffalogs_nginx
         image: nginx:mainline-alpine
         hostname: nginx
+        networks:
+            - buffalogs_network
         depends_on:
             - buffalogs
         volumes:
@@ -42,6 +46,8 @@ services:
             dockerfile: build/Dockerfile
         image: certego/buffalogs
         hostname: buffalogs
+        networks:
+            - buffalogs_network
         env_file:
             -  config/buffalogs/buffalogs.env
         volumes:
@@ -57,6 +63,8 @@ services:
         container_name: buffalogs_rabbitmq
         image: rabbitmq:3.13-management-alpine
         hostname: rabbitmq
+        networks:
+            - buffalogs_network
         volumes:
             - ./config/rabbitmq:/etc/rabbitmq:ro
             - buffalogs_rabbitmq_data:/var/lib/rabbitmq
@@ -70,6 +78,8 @@ services:
         container_name: buffalogs_celery
         image: buffalogs:latest
         hostname: celery
+        networks:
+            - buffalogs_network
         build:
             context: .
             dockerfile: build/Dockerfile
@@ -90,6 +100,8 @@ services:
             dockerfile: build/Dockerfile
         image: buffalogs:latest
         hostname: celery_beat
+        networks:
+            - buffalogs_network
         env_file:
             - config/buffalogs/buffalogs.env
         command:
@@ -105,6 +117,8 @@ services:
         build:
             context: ./frontend
             dockerfile: Dockerfile
+        networks:
+            - buffalogs_network
         ports:
             - "3000:3000"
         environment:
@@ -131,3 +145,8 @@ volumes:
         driver: local
     buffalogs_rabbitmq_data:
         driver: local
+
+networks:
+    buffalogs_network:
+        driver: bridge
+        name: buffalogs_network


### PR DESCRIPTION
Fix to issue number 2 which causes errors while generating fake elasticsearch data during development.
Update docker-compose yamls to define a bridge network buffalogs_network and add other networks (elk, opensearch-net, splunk-net) so that they can communicate with each other.
Fixes data generation of (#480) by
`docker compose exec buffalogs python manage.py generate_fake_elasticsearch_data`