### PR TITLE
fix: correct API endpoints and field mapping in frontend dashboard

### DIFF
--- a/frontend/components/LogsTable.tsx
+++ b/frontend/components/LogsTable.tsx
@@ -8,7 +8,7 @@ import { getAlerts } from "@/lib/requestdata";
 
 interface RowData {
   timestamp: string;
-  username: string;
+  triggered_by: string;
   rule_name: string;
 }
 
@@ -21,7 +21,7 @@ const TableComponent: React.FC = () => {
   const [data, setData] = useState<RowData[]>([]);
   const columnDefs: ColDef[] = [
     { headerName: "Timestamp", field: "timestamp" },
-    { headerName: "Username", field: "username" },
+    { headerName: "Username", field: "triggered_by" },
     { headerName: "Rule Name", field: "rule_name" },
   ];
 

--- a/frontend/components/PieChart.tsx
+++ b/frontend/components/PieChart.tsx
@@ -75,7 +75,7 @@ const Piechart: React.FC = () => {
     fill,
     value,
     payload,
-  }: ActiveShapeProps) => {
+  }: any) => {
     const RADIAN = Math.PI / 180;
 
     const sin = Math.sin(-RADIAN * midAngle);

--- a/frontend/lib/requestdata.ts
+++ b/frontend/lib/requestdata.ts
@@ -34,7 +34,7 @@ async function fetchData(
 // Each API function now delegates to fetchData
 export async function getUsersPieChart(dateRange?: DateRange): Promise<any> {
     return fetchData(
-        "users_pie_chart_api",
+        "api/analytics/chart/users/pie/",
         "Failed to fetch users pie chart data",
         dateRange
     );
@@ -42,7 +42,7 @@ export async function getUsersPieChart(dateRange?: DateRange): Promise<any> {
 
 export async function getAlertsLineChart(dateRange?: DateRange): Promise<any> {
     return fetchData(
-        "alerts_line_chart_api",
+        "api/analytics/chart/alerts/line/",
         "Failed to fetch users alerts chart data",
         dateRange
     );
@@ -50,7 +50,7 @@ export async function getAlertsLineChart(dateRange?: DateRange): Promise<any> {
 
 export async function getWorldMapChart(dateRange?: DateRange): Promise<any> {
     return fetchData(
-        "world_map_chart_api",
+        "api/analytics/chart/world-map/",
         "Failed to fetch users world chart data",
         dateRange
     );
@@ -58,7 +58,7 @@ export async function getWorldMapChart(dateRange?: DateRange): Promise<any> {
 
 export async function getAlerts(dateRange?: DateRange): Promise<any> {
     return fetchData(
-        "alerts_api",
+        "api/alerts/",
         "Failed to fetch alerts",
         dateRange
     );


### PR DESCRIPTION
This pull request updates several frontend components and API endpoints to improve naming consistency and align with backend changes. The main changes involve updating field names in the logs table, switching API endpoint strings to their correct paths, and making a minor type adjustment in the pie chart component.

**Field and API Endpoint Updates:**

* Changed the `RowData` interface and table column definition in `LogsTable.tsx` to use `triggered_by` instead of `username`, ensuring consistency with backend data. [[1]](diffhunk://#diff-d5a98304a49b35bf642514a5bd83e0a452d6ee0f756a54fc485ed1ba66a0fe57L11-R11) [[2]](diffhunk://#diff-d5a98304a49b35bf642514a5bd83e0a452d6ee0f756a54fc485ed1ba66a0fe57L24-R24)
* Updated API endpoint strings in `requestdata.ts` to use the correct RESTful paths (e.g., `"api/analytics/chart/users/pie/"` instead of `"users_pie_chart_api"`), improving maintainability and clarity.

**Type Adjustments:**

* Changed the `ActiveShapeProps` parameter type to `any` in the `PieChart.tsx` component, likely to resolve a type mismatch or simplify prop handling.
---
Related Issues : #486 