### PR TITLE
Added postgresql-client to Dockerfile to use dbshell in buffalogs container

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,9 +7,11 @@ COPY buffalogs/requirements.txt requirements.txt
 
 
 RUN sed -i 's/main/main non-free/g' /etc/apt/sources.list.d/debian.sources \
-    && apt-get update \
-    && apt-get -y install \
-        gcc
+ && apt-get update \
+ && apt-get -y install \
+    gcc \
+    postgresql-client
+
 
 RUN pip install --no-cache-dir -r requirements.txt \
     && rm -f requirements.txt && apt-get -y purge gcc && apt-get -y autoremove && apt-get -y clean


### PR DESCRIPTION
### Problem

Running `python manage.py dbshell` inside the `buffalogs` Django container fails with:

CommandError: You appear not to have the 'psql' program installed or on your path.

This makes it impossible to inspect the database from inside the container.

### Steps to Reproduce

1. Run the stack with:

   docker compose up -d

2. Enter the Django container:

   docker compose exec buffalogs bash
   python manage.py dbshell

3. Observe the error above.

### Fix

Added `postgresql-client` to the apt dependencies in `build/Dockerfile` so the `psql` binary is available inside the Django container.

### Verification

After rebuilding the image:

docker compose exec buffalogs bash
command -v psql
python manage.py dbshell

`dbshell` now opens correctly.
