### PR TITLE
Fix AlertAdminForm tags field and MultiChoiceArrayField issues in Dja…

### DIFF
--- a/buffalogs/impossible_travel/forms.py
+++ b/buffalogs/impossible_travel/forms.py
@@ -1,7 +1,9 @@
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
-from .constants import (AlertDetectionType, AlertFilterType, AlertTagValues,UserRiskScoreType,)
+
+from .constants import AlertDetectionType, AlertFilterType, AlertTagValues, UserRiskScoreType
 from .models import Alert, Config, TaskSettings, User
+
 
 class MultiChoiceArrayWidget(forms.SelectMultiple):
     """Widget for user-friendly interface for ArrayField with multiple choices"""
@@ -30,6 +32,7 @@ class MultiChoiceArrayField(SimpleArrayField):
             return []
         return value
 
+
 class ShortLabelChoiceField(forms.ChoiceField):
     """ChoiceField personalized in order to show the short_value as label on DjangoValue"""
 
@@ -37,6 +40,7 @@ class ShortLabelChoiceField(forms.ChoiceField):
         choices = kwargs.pop("choices", [])
         formatted_choices = [("", "---------")] + [(value, value) for value, _ in choices]
         super().__init__(*args, choices=formatted_choices, required=False, **kwargs)
+
 
 class UserAdminForm(forms.ModelForm):
     risk_score = ShortLabelChoiceField(choices=UserRiskScoreType.choices)

--- a/buffalogs/impossible_travel/forms.py
+++ b/buffalogs/impossible_travel/forms.py
@@ -1,14 +1,7 @@
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
-
-from .constants import (
-    AlertDetectionType,
-    AlertFilterType,
-    AlertTagValues,
-    UserRiskScoreType,
-)
+from .constants import (AlertDetectionType, AlertFilterType, AlertTagValues,UserRiskScoreType,)
 from .models import Alert, Config, TaskSettings, User
-
 
 class MultiChoiceArrayWidget(forms.SelectMultiple):
     """Widget for user-friendly interface for ArrayField with multiple choices"""
@@ -36,7 +29,6 @@ class MultiChoiceArrayField(SimpleArrayField):
         if value is None:
             return []
         return value
-
 
 class ShortLabelChoiceField(forms.ChoiceField):
     """ChoiceField personalized in order to show the short_value as label on DjangoValue"""

--- a/buffalogs/impossible_travel/forms.py
+++ b/buffalogs/impossible_travel/forms.py
@@ -1,7 +1,12 @@
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 
-from .constants import AlertDetectionType, AlertFilterType, UserRiskScoreType
+from .constants import (
+    AlertDetectionType,
+    AlertFilterType,
+    AlertTagValues,
+    UserRiskScoreType,
+)
 from .models import Alert, Config, TaskSettings, User
 
 
@@ -41,7 +46,6 @@ class ShortLabelChoiceField(forms.ChoiceField):
         formatted_choices = [("", "---------")] + [(value, value) for value, _ in choices]
         super().__init__(*args, choices=formatted_choices, required=False, **kwargs)
 
-
 class UserAdminForm(forms.ModelForm):
     risk_score = ShortLabelChoiceField(choices=UserRiskScoreType.choices)
 
@@ -51,12 +55,21 @@ class UserAdminForm(forms.ModelForm):
 
 
 class AlertAdminForm(forms.ModelForm):
-    name = ShortLabelChoiceField(choices=AlertDetectionType.choices)
-    filter_type = ShortLabelChoiceField(choices=AlertFilterType.choices)
+    name = forms.ChoiceField(choices=AlertDetectionType.choices, required=True)
+    filter_type = forms.ChoiceField(choices=AlertFilterType.choices, required=True)
+    tags = forms.MultipleChoiceField(
+        choices=[(tag, tag) for tag, _ in AlertTagValues.choices],
+        widget=forms.SelectMultiple(attrs={"size": "1"}),
+        required=False,
+    )
 
     class Meta:
         model = Alert
         fields = "__all__"
+
+    def clean_tags(self):
+        tags = self.data.getlist("tags")
+        return tags or []
 
 
 class ConfigAdminForm(forms.ModelForm):


### PR DESCRIPTION
**Description**
This PR fixes the tags field behavior in the Django Admin for the Alert model.
Previously, the tags ArrayField was rendered as a free-text input or appeared empty due to incorrect form/widget configuration. Multiple attempts using custom widgets and SimpleArrayField caused admin page crashes and internal server errors.

**1. **Steps to Reproduce****
- Start the Django development server 
   Run the command : python manage.py runserver on virtual environment

-  Use the command : "docker restart buffalogs" 
    run the command  on the project root (BuffaLogs)

- Go to the admin panel
   http://127.0.0.1:8001/admin/

- Open any existing Alert object or create a new one
- Observe the tags field:
   Renders as a free-text input or
   Renders empty with no selectable values or
   Admin page crashes with HTTP 500 error

**2. Evidence** 
-  Django Admin returned:
    500 Internal Server Error

- Tracebacks included errors such as:
   TypeError: Field.__init__() got an unexpected keyword argument 'base_field'

**3. **Attempted Solutions**** 
-  Tried using filter_horizontal → only works with ManyToManyField
- Custom SimpleArrayField + widgets →  broke admin rendering
- Passing base_field to MultipleChoiceField →  invalid argument
- Overriding admin widgets directly →  values disappeared

**4. **Changes**** 

- Simplified tags handling by removing Select2 and custom widgets.
- Replaced complex multi-select configuration with a standard MultipleChoiceField.
- Added explicit clean_tags() implementation to correctly parse multi-value inputs from admin POST data.
- Prevented invalid None values by normalizing empty selections to an empty list.
- Reduced admin form complexity and eliminated prior widget-related errors.

**5. **Results and Screenshots****
-  Django Admin loads successfully
- Tags render as a searchable multi-select dropdown
- Multiple tags can be selected and saved
- Existing tag values are preserved
- No runtime errors or admin crashes

![image](https://github.com/user-attachments/assets/c5d70982-bb5b-43b3-a5df-a624785d39df)


 Closes #497 





