### PR TITLE
perf: add indexes for Login filter fields

### DIFF
--- a/buffalogs/impossible_travel/migrations/0023_login_filter_indexes.py
+++ b/buffalogs/impossible_travel/migrations/0023_login_filter_indexes.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("impossible_travel", "0022_remove_tasksettings_unique_task_execution_mode_and_more"),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name="login",
+            index=models.Index(fields=["timestamp"], name="login_timestamp_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="login",
+            index=models.Index(fields=["ip"], name="login_ip_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="login",
+            index=models.Index(fields=["country"], name="login_country_idx"),
+        ),
+        migrations.AddIndex(
+            model_name="login",
+            index=models.Index(fields=["event_id"], name="login_event_id_idx"),
+        ),
+    ]

--- a/buffalogs/impossible_travel/models.py
+++ b/buffalogs/impossible_travel/models.py
@@ -97,6 +97,14 @@ class Login(models.Model):
 
         return query
 
+    class Meta:
+        indexes = [
+            models.Index(fields=["timestamp"], name="login_timestamp_idx"),
+            models.Index(fields=["ip"], name="login_ip_idx"),
+            models.Index(fields=["country"], name="login_country_idx"),
+            models.Index(fields=["event_id"], name="login_event_id_idx"),
+        ]
+
 
 class Alert(models.Model):
     name = models.CharField(choices=AlertDetectionType.choices, max_length=30, null=False, blank=False)


### PR DESCRIPTION
Fixes #494 

### Improve Login query performance by adding DB indexes

**Problem**
Queries on the `Login` model were causing sequential scans when filtering by
`timestamp`, `ip`, `country`, and `event_id`, leading to poor performance on large datasets.

**Solution**
Add database indexes for the most commonly filtered fields in `Login`:
- timestamp
- ip
- country
- event_id

The `index` field is intentionally not indexed, as previously discussed.

**Scope**
- Login model only
- Single migration
- No unrelated file changes
