### PR TITLE
Fixes Issue 544: Added path to save `celerybeat-schedule` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 **/.DS_Store
 *.egg-info/
 /node_modules
+celerybeat-schedule

--- a/buffalogs/run_beat.sh
+++ b/buffalogs/run_beat.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-celery -A buffalogs beat --schedule /tmp/celerybeat-schedule
+celery -A buffalogs beat

--- a/buffalogs/run_beat.sh
+++ b/buffalogs/run_beat.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-celery -A buffalogs beat
+celery -A buffalogs beat --schedule /tmp/celerybeat-schedule


### PR DESCRIPTION
This PR fixes #544 by adding a custom path to save the `celerybeat-schedule` which is created by Celery Beat.

**Screenshots**

<img width="1919" height="875" alt="Screenshot from 2026-01-23 21-06-04" src="https://github.com/user-attachments/assets/e477cc0f-5479-4537-b587-36371b441af4" />

<img width="1297" height="182" alt="Screenshot from 2026-01-23 21-06-35" src="https://github.com/user-attachments/assets/02d2c28a-5659-4fbb-b3c5-fa6184c0dd0c" />

