### PR TITLE
fix: correctly parse multi-value list flags in setup_config (#539)

### DIFF
--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -7,7 +7,13 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.exceptions import ValidationError
 from django.core.management.base import CommandError
 from django.db.models.fields import Field
-from impossible_travel.management.commands import base_command
+
+# isort: off
+from impossible_travel.management.commands.base_command import (
+    TaskLoggingCommand,
+)
+
+# isort: on
 from impossible_travel.models import Config
 
 logger = logging.getLogger()
@@ -79,7 +85,7 @@ def _reassemble_bracketed_args(items):
     return result
 
 
-class Command(base_command.TaskLoggingCommand):
+class Command(TaskLoggingCommand):
     def create_parser(self, *args, **kwargs):
         config_fields = [
             f.name
@@ -151,11 +157,7 @@ class Command(base_command.TaskLoggingCommand):
         parser.add_argument(
             "--force",
             action="store_true",
-            help=(
-                "Force overwrite existing values with defaults "
-                # split for black
-                "(use with caution)"
-            ),
+            help="Force overwrite existing values with defaults (use with caution)",  # noqa: E501
         )
 
     def handle(self, *args, **options):
@@ -194,14 +196,8 @@ class Command(base_command.TaskLoggingCommand):
 
             config.save()
 
-            msg_forced = (
-                f"BuffaLogs Config: all {len(updated_fields)} fields "
-                "reset to defaults (FORCED)."
-            )
-            msg_updated = (
-                f"BuffaLogs Config: updated {len(updated_fields)} "
-                "empty fields with defaults."
-            )
+            msg_forced = f"BuffaLogs Config: all {len(updated_fields)} fields reset to defaults (FORCED)."  # noqa: E501
+            msg_updated = f"BuffaLogs Config: updated {len(updated_fields)} empty fields with defaults."  # noqa: E501
             msg = msg_forced if force else msg_updated
             self.stdout.write(self.style.SUCCESS(msg))
             return
@@ -222,8 +218,9 @@ class Command(base_command.TaskLoggingCommand):
 
         for field, mode, value in updates:
             if field not in fields_info:
-                msg_err = f"Field '{field}' does not exist in Config model."
-                raise CommandError(msg_err)
+                raise CommandError(
+                    f"Field '{field}' does not exist in Config model."
+                )  # noqa: E501
 
             field_obj = fields_info[field]
             is_list = isinstance(field_obj, ArrayField)

--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -50,6 +50,7 @@ def parse_field_value(item: str) -> Tuple[str, Any]:
 
     return field.strip(), parsed
 
+
 def _reassemble_bracketed_args(items):
     """
     Reassemble argparse-split list arguments like:
@@ -77,9 +78,14 @@ def _reassemble_bracketed_args(items):
 
     return result
 
+
 class Command(TaskLoggingCommand):
     def create_parser(self, *args, **kwargs):
-        config_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
+        config_fields = [
+            f.name
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        ]
 
         help_text = f"""
         Update values in the Config model.
@@ -108,19 +114,47 @@ class Command(TaskLoggingCommand):
 
     def add_arguments(self, parser):
         super().add_arguments(parser)
-        parser.add_argument("-o", "--override", action="append", metavar="FIELD=[VALUES]", help="Override field values")
-        parser.add_argument("-r", "--remove", action="append", metavar="FIELD=[VALUES]", help="Remove values from list fields")
-        parser.add_argument("-a", "--append", action="append", metavar="FIELD=[VALUES]", help="Append values to list fields or override non-list")
         parser.add_argument(
-            "--set-default-values", action="store_true", help="Initialize configuration fields with default values (already populated values are not modified)"
+            "-o",
+            "--override",
+            action="append",
+            metavar="FIELD=[VALUES]",
+            help="Override field values",
         )
-        parser.add_argument("--force", action="store_true", help="Force overwrite existing values with defaults (use with caution)")
+        parser.add_argument(
+            "-r",
+            "--remove",
+            action="append",
+            metavar="FIELD=[VALUES]",
+            help="Remove values from list fields",
+        )
+        parser.add_argument(
+            "-a",
+            "--append",
+            action="append",
+            metavar="FIELD=[VALUES]",
+            help="Append values to list fields or override non-list",
+        )
+        parser.add_argument(
+            "--set-default-values",
+            action="store_true",
+            help="Initialize configuration fields with default values (already populated values are not modified)",
+        )
+        parser.add_argument(
+            "--force",
+            action="store_true",
+            help="Force overwrite existing values with defaults (use with caution)",
+        )
 
     def handle(self, *args, **options):
         config, _ = Config.objects.get_or_create(id=1)
 
         # get customizable fields in the Config model dinamically
-        fields_info = {f.name: f for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created}
+        fields_info = {
+            f.name: f
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        }
 
         # MODE: --set-default-values
         if options.get("set_default_values"):
@@ -129,7 +163,11 @@ class Command(TaskLoggingCommand):
 
             for field_name, field_model in list(fields_info.items()):
                 if hasattr(field_model, "default"):
-                    default_value = field_model.default() if callable(field_model.default) else field_model.default
+                    default_value = (
+                        field_model.default()
+                        if callable(field_model.default)
+                        else field_model.default
+                    )
                     current_value = getattr(config, field_name)
 
                     # Safe mode --> update field only if it's empty
@@ -154,7 +192,7 @@ class Command(TaskLoggingCommand):
 
         # MODE: manual updates (--override, --append, --remove)
         updates = []
-        
+
         for mode, items in [
             ("override", options["override"]),
             ("remove", options["remove"]),
@@ -185,7 +223,9 @@ class Command(TaskLoggingCommand):
                     try:
                         validator(val)
                     except ValidationError as e:
-                        raise CommandError(f"Validation error on field '{field}' with value '{val}': {e}")
+                        raise CommandError(
+                            f"Validation error on field '{field}' with value '{val}': {e}"
+                        )
 
             # Apply changes
             if is_list:
@@ -198,7 +238,9 @@ class Command(TaskLoggingCommand):
                     current = [item for item in current if item not in value]
             else:
                 if mode != "override":
-                    raise CommandError(f"Field '{field}' is not a list. Use --override to set its value.")
+                    raise CommandError(
+                        f"Field '{field}' is not a list. Use --override to set its value."
+                    )
                 current = value
 
             setattr(config, field, current)

--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -81,11 +81,7 @@ def _reassemble_bracketed_args(items):
 
 class Command(TaskLoggingCommand):
     def create_parser(self, *args, **kwargs):
-        config_fields = [
-            f.name
-            for f in Config._meta.get_fields()
-            if isinstance(f, Field) and f.editable and not f.auto_created
-        ]
+        config_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
 
         help_text = f"""
         Update values in the Config model.
@@ -150,11 +146,7 @@ class Command(TaskLoggingCommand):
         config, _ = Config.objects.get_or_create(id=1)
 
         # get customizable fields in the Config model dinamically
-        fields_info = {
-            f.name: f
-            for f in Config._meta.get_fields()
-            if isinstance(f, Field) and f.editable and not f.auto_created
-        }
+        fields_info = {f.name: f for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created}
 
         # MODE: --set-default-values
         if options.get("set_default_values"):
@@ -163,11 +155,7 @@ class Command(TaskLoggingCommand):
 
             for field_name, field_model in list(fields_info.items()):
                 if hasattr(field_model, "default"):
-                    default_value = (
-                        field_model.default()
-                        if callable(field_model.default)
-                        else field_model.default
-                    )
+                    default_value = field_model.default() if callable(field_model.default) else field_model.default
                     current_value = getattr(config, field_name)
 
                     # Safe mode --> update field only if it's empty
@@ -223,9 +211,7 @@ class Command(TaskLoggingCommand):
                     try:
                         validator(val)
                     except ValidationError as e:
-                        raise CommandError(
-                            f"Validation error on field '{field}' with value '{val}': {e}"
-                        )
+                        raise CommandError(f"Validation error on field '{field}' with value '{val}': {e}")
 
             # Apply changes
             if is_list:
@@ -238,9 +224,7 @@ class Command(TaskLoggingCommand):
                     current = [item for item in current if item not in value]
             else:
                 if mode != "override":
-                    raise CommandError(
-                        f"Field '{field}' is not a list. Use --override to set its value."
-                    )
+                    raise CommandError(f"Field '{field}' is not a list. Use --override to set its value.")
                 current = value
 
             setattr(config, field, current)

--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -1,3 +1,4 @@
+import ast
 import logging
 from argparse import RawTextHelpFormatter
 from typing import Any, Tuple
@@ -39,8 +40,11 @@ def parse_field_value(item: str) -> Tuple[str, Any]:
     value = value.strip()
 
     if value.startswith("[") and value.endswith("]"):
-        inner = value[1:-1].strip()
-        parsed = [_cast_value(v) for v in inner.split(",") if v.strip()]
+        try:
+            parsed = ast.literal_eval(value)
+        except (ValueError, SyntaxError):
+            inner = value[1:-1].strip()
+            parsed = [_cast_value(v) for v in inner.split(",") if v.strip()]
     else:
         parsed = _cast_value(value)
 

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -6,10 +6,7 @@ from django.core.management import CommandError, call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
-from impossible_travel.management.commands.setup_config import (
-    Command,
-    parse_field_value,
-)
+from impossible_travel.management.commands.setup_config import Command, parse_field_value
 from impossible_travel.models import (
     Config,
     User,

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -1,8 +1,5 @@
-import io
-from unittest.mock import patch
-
 from django.conf import settings
-from django.core.management import CommandError, call_command
+from django.core.management import call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -6,19 +6,17 @@ from django.core.management import CommandError, call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
-from impossible_travel.management.commands.setup_config import Command, parse_field_value
-from impossible_travel.models import (
-    Config,
-    User,
-    get_default_allowed_countries,
-    get_default_enabled_users,
-    get_default_filtered_alerts_types,
-    get_default_ignored_ips,
-    get_default_ignored_ISPs,
-    get_default_ignored_users,
-    get_default_risk_score_increment_alerts,
-    get_default_vip_users,
-)
+from impossible_travel.management.commands.setup_config import (
+    Command, parse_field_value)
+from impossible_travel.models import (Config, User,
+                                      get_default_allowed_countries,
+                                      get_default_enabled_users,
+                                      get_default_filtered_alerts_types,
+                                      get_default_ignored_ips,
+                                      get_default_ignored_ISPs,
+                                      get_default_ignored_users,
+                                      get_default_risk_score_increment_alerts,
+                                      get_default_vip_users)
 
 
 class TestSetupConfigCommand(TestCase):
@@ -30,7 +28,9 @@ class TestSetupConfigCommand(TestCase):
         )
 
         config = Config.objects.get(id=1)
-        self.assertEqual(
+
+        # Order is NOT guaranteed → compare contents only
+        self.assertCountEqual(
             config.filtered_alerts_types,
             ["New Device", "User Risk Threshold", "Anonymous IP Login"],
         )
@@ -101,14 +101,20 @@ class ManagementCommandsTestCase(TestCase):
         config.refresh_from_db()
         # check updated config values
         self.assertTrue(config.ignore_mobile_logins)
-        self.assertListEqual(config.filtered_alerts_types, ["New Device", "User Risk Threshold"])
+        self.assertListEqual(
+            config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
+        )
         self.assertEqual(config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM)
         self.assertEqual(config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM)
 
     def test_handle_set_default_values_force(self):
         # Testing the option --set-default-values (force mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
+        config_editable_fields = [
+            f.name
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        ]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
@@ -127,7 +133,9 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+        )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -146,24 +154,38 @@ class ManagementCommandsTestCase(TestCase):
             get_default_risk_score_increment_alerts(),
         )
         self.assertListEqual(self.config.ignored_ips, get_default_ignored_ips())
-        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
+        self.assertListEqual(
+            self.config.allowed_countries, get_default_allowed_countries()
+        )
         self.assertListEqual(self.config.ignored_ISPs, get_default_ignored_ISPs())
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
+        self.assertListEqual(
+            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+        )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
             self.config.distance_accepted,
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
-        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
+        self.assertEqual(
+            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+        )
         self.assertEqual(
             self.config.atypical_country_days,
             settings.CERTEGO_BUFFALOGS_ATYPICAL_COUNTRY_DAYS,
         )
-        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
-        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
-        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
-        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
+        self.assertEqual(
+            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
+        )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
         self.assertEqual(
@@ -174,7 +196,11 @@ class ManagementCommandsTestCase(TestCase):
     def test_handle_set_default_values_safe(self):
         # Testing the option --set-default-values (safe mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
+        config_editable_fields = [
+            f.name
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        ]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
@@ -194,7 +220,9 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+        )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -213,21 +241,35 @@ class ManagementCommandsTestCase(TestCase):
             [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY],
         )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
-        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
+        self.assertListEqual(
+            self.config.allowed_countries, get_default_allowed_countries()
+        )
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
+        self.assertListEqual(
+            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+        )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
             self.config.distance_accepted,
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
-        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
+        self.assertEqual(
+            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+        )
         self.assertEqual(self.config.atypical_country_days, 80)
-        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
-        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
-        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
-        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
+        self.assertEqual(
+            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
+        )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
         self.assertEqual(self.config.user_learning_period, 20)
@@ -268,19 +310,29 @@ class ManagementCommandsTestCase(TestCase):
         actual_field_str, actual_value_str = parse_field_value("enabled_users=admin")
         self.assertEqual(actual_field_str, "enabled_users")
         self.assertEqual(actual_value_str, "admin")
-        actual_field_list, actual_value_list = parse_field_value("ignored_users=[lorygold]")
+        actual_field_list, actual_value_list = parse_field_value(
+            "ignored_users=[lorygold]"
+        )
         self.assertEqual(actual_field_list, "ignored_users")
         self.assertEqual(actual_value_list, ["lorygold"])
-        actual_field_list2, actual_value_list2 = parse_field_value('vip_users=["lory", "gold"]')
+        actual_field_list2, actual_value_list2 = parse_field_value(
+            'vip_users=["lory", "gold"]'
+        )
         self.assertEqual(actual_field_list2, "vip_users")
         self.assertListEqual(actual_value_list2, ["lory", "gold"])
 
     def test_parse_field_value_list_multiple_values_correct(self):
         # Testing the parse_field_value function with multiple str/regex values for a str list field
-        actual_field_list, actual_value_list = parse_field_value("enabled_users=[admin@gmaail.com, lory.gold, pluto123]")
+        actual_field_list, actual_value_list = parse_field_value(
+            "enabled_users=[admin@gmaail.com, lory.gold, pluto123]"
+        )
         self.assertEqual(actual_field_list, "enabled_users")
-        self.assertEqual(actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"])
-        actual_field_regex, actual_value_regex = parse_field_value("enabled_users=[*1.@*, *@acompany_name.com, pluto]")
+        self.assertEqual(
+            actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"]
+        )
+        actual_field_regex, actual_value_regex = parse_field_value(
+            "enabled_users=[*1.@*, *@acompany_name.com, pluto]"
+        )
         self.assertEqual(actual_field_regex, "enabled_users")
         self.assertEqual(actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"])
 
@@ -322,7 +374,9 @@ class ResetUserRiskScoreCommandTests(TestCase):
 
     def test_update_single_user_success(self):
         out = io.StringIO()
-        call_command("reset_user_risk_score", username="alice", risk_score="Medium", stdout=out)
+        call_command(
+            "reset_user_risk_score", username="alice", risk_score="Medium", stdout=out
+        )
         alice = User.objects.get(username="alice")
         bob = User.objects.get(username="bob")
         self.assertEqual(alice.risk_score, "Medium")
@@ -337,7 +391,9 @@ class ResetUserRiskScoreCommandTests(TestCase):
         out = io.StringIO()
         call_command("reset_user_risk_score", risk_score="No risk", stdout=out)
         self.assertEqual(User.objects.filter(risk_score="No risk").count(), 2)
-        self.assertIn("Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue())
+        self.assertIn(
+            "Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue()
+        )
 
     def test_invalid_risk_score_raises(self):
         with self.assertRaises(CommandError) as cm:
@@ -357,15 +413,21 @@ class ResetUserRiskScoreCommandTests(TestCase):
         out = io.StringIO()
         # default should be 'No risk'
         call_command("reset_user_risk_score", stdout=out)
-        self.assertEqual(User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2)
+        self.assertEqual(
+            User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2
+        )
 
     def test_single_user_triggers_save(self):
-        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save:
+        with patch(
+            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+        ) as mock_save:
             call_command("reset_user_risk_score", username="alice", risk_score="Low")
             self.assertTrue(mock_save.called)
 
     def test_bulk_update_uses_update_not_save(self):
-        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save, patch(
+        with patch(
+            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+        ) as mock_save, patch(
             "impossible_travel.management.commands.reset_user_risk_score.User.objects.update"
         ) as mock_update:
             mock_update.return_value = 2
@@ -373,4 +435,6 @@ class ResetUserRiskScoreCommandTests(TestCase):
             call_command("reset_user_risk_score", risk_score="Low", stdout=out)
             mock_update.assert_called_once_with(risk_score="Low")
             self.assertFalse(mock_save.called)
-            self.assertIn("Successfully updated risk_score for 2 users to 'Low'.", out.getvalue())
+            self.assertIn(
+                "Successfully updated risk_score for 2 users to 'Low'.", out.getvalue()
+            )

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -1,5 +1,8 @@
+import io
+from unittest.mock import patch
+
 from django.conf import settings
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -101,20 +101,14 @@ class ManagementCommandsTestCase(TestCase):
         config.refresh_from_db()
         # check updated config values
         self.assertTrue(config.ignore_mobile_logins)
-        self.assertListEqual(
-            config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
-        )
+        self.assertListEqual(config.filtered_alerts_types, ["New Device", "User Risk Threshold"])
         self.assertEqual(config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM)
         self.assertEqual(config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM)
 
     def test_handle_set_default_values_force(self):
         # Testing the option --set-default-values (force mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [
-            f.name
-            for f in Config._meta.get_fields()
-            if isinstance(f, Field) and f.editable and not f.auto_created
-        ]
+        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
@@ -133,9 +127,7 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(
-            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
-        )
+        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -154,38 +146,24 @@ class ManagementCommandsTestCase(TestCase):
             get_default_risk_score_increment_alerts(),
         )
         self.assertListEqual(self.config.ignored_ips, get_default_ignored_ips())
-        self.assertListEqual(
-            self.config.allowed_countries, get_default_allowed_countries()
-        )
+        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
         self.assertListEqual(self.config.ignored_ISPs, get_default_ignored_ISPs())
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(
-            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
-        )
+        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
             self.config.distance_accepted,
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
-        self.assertEqual(
-            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
-        )
+        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
         self.assertEqual(
             self.config.atypical_country_days,
             settings.CERTEGO_BUFFALOGS_ATYPICAL_COUNTRY_DAYS,
         )
-        self.assertEqual(
-            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
-        )
+        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
+        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
+        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
+        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
         self.assertEqual(
@@ -196,11 +174,7 @@ class ManagementCommandsTestCase(TestCase):
     def test_handle_set_default_values_safe(self):
         # Testing the option --set-default-values (safe mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [
-            f.name
-            for f in Config._meta.get_fields()
-            if isinstance(f, Field) and f.editable and not f.auto_created
-        ]
+        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
@@ -220,9 +194,7 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(
-            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
-        )
+        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -241,35 +213,21 @@ class ManagementCommandsTestCase(TestCase):
             [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY],
         )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
-        self.assertListEqual(
-            self.config.allowed_countries, get_default_allowed_countries()
-        )
+        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(
-            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
-        )
+        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
             self.config.distance_accepted,
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
-        self.assertEqual(
-            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
-        )
+        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
         self.assertEqual(self.config.atypical_country_days, 80)
-        self.assertEqual(
-            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
-        )
-        self.assertEqual(
-            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
-        )
+        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
+        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
+        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
+        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
         self.assertEqual(self.config.user_learning_period, 20)
@@ -310,29 +268,19 @@ class ManagementCommandsTestCase(TestCase):
         actual_field_str, actual_value_str = parse_field_value("enabled_users=admin")
         self.assertEqual(actual_field_str, "enabled_users")
         self.assertEqual(actual_value_str, "admin")
-        actual_field_list, actual_value_list = parse_field_value(
-            "ignored_users=[lorygold]"
-        )
+        actual_field_list, actual_value_list = parse_field_value("ignored_users=[lorygold]")
         self.assertEqual(actual_field_list, "ignored_users")
         self.assertEqual(actual_value_list, ["lorygold"])
-        actual_field_list2, actual_value_list2 = parse_field_value(
-            'vip_users=["lory", "gold"]'
-        )
+        actual_field_list2, actual_value_list2 = parse_field_value('vip_users=["lory", "gold"]')
         self.assertEqual(actual_field_list2, "vip_users")
         self.assertListEqual(actual_value_list2, ["lory", "gold"])
 
     def test_parse_field_value_list_multiple_values_correct(self):
         # Testing the parse_field_value function with multiple str/regex values for a str list field
-        actual_field_list, actual_value_list = parse_field_value(
-            "enabled_users=[admin@gmaail.com, lory.gold, pluto123]"
-        )
+        actual_field_list, actual_value_list = parse_field_value("enabled_users=[admin@gmaail.com, lory.gold, pluto123]")
         self.assertEqual(actual_field_list, "enabled_users")
-        self.assertEqual(
-            actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"]
-        )
-        actual_field_regex, actual_value_regex = parse_field_value(
-            "enabled_users=[*1.@*, *@acompany_name.com, pluto]"
-        )
+        self.assertEqual(actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"])
+        actual_field_regex, actual_value_regex = parse_field_value("enabled_users=[*1.@*, *@acompany_name.com, pluto]")
         self.assertEqual(actual_field_regex, "enabled_users")
         self.assertEqual(actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"])
 
@@ -374,9 +322,7 @@ class ResetUserRiskScoreCommandTests(TestCase):
 
     def test_update_single_user_success(self):
         out = io.StringIO()
-        call_command(
-            "reset_user_risk_score", username="alice", risk_score="Medium", stdout=out
-        )
+        call_command("reset_user_risk_score", username="alice", risk_score="Medium", stdout=out)
         alice = User.objects.get(username="alice")
         bob = User.objects.get(username="bob")
         self.assertEqual(alice.risk_score, "Medium")
@@ -391,9 +337,7 @@ class ResetUserRiskScoreCommandTests(TestCase):
         out = io.StringIO()
         call_command("reset_user_risk_score", risk_score="No risk", stdout=out)
         self.assertEqual(User.objects.filter(risk_score="No risk").count(), 2)
-        self.assertIn(
-            "Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue()
-        )
+        self.assertIn("Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue())
 
     def test_invalid_risk_score_raises(self):
         with self.assertRaises(CommandError) as cm:
@@ -413,21 +357,15 @@ class ResetUserRiskScoreCommandTests(TestCase):
         out = io.StringIO()
         # default should be 'No risk'
         call_command("reset_user_risk_score", stdout=out)
-        self.assertEqual(
-            User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2
-        )
+        self.assertEqual(User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2)
 
     def test_single_user_triggers_save(self):
-        with patch(
-            "impossible_travel.management.commands.reset_user_risk_score.User.save"
-        ) as mock_save:
+        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save:
             call_command("reset_user_risk_score", username="alice", risk_score="Low")
             self.assertTrue(mock_save.called)
 
     def test_bulk_update_uses_update_not_save(self):
-        with patch(
-            "impossible_travel.management.commands.reset_user_risk_score.User.save"
-        ) as mock_save, patch(
+        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save, patch(
             "impossible_travel.management.commands.reset_user_risk_score.User.objects.update"
         ) as mock_update:
             mock_update.return_value = 2
@@ -435,6 +373,4 @@ class ResetUserRiskScoreCommandTests(TestCase):
             call_command("reset_user_risk_score", risk_score="Low", stdout=out)
             mock_update.assert_called_once_with(risk_score="Low")
             self.assertFalse(mock_save.called)
-            self.assertIn(
-                "Successfully updated risk_score for 2 users to 'Low'.", out.getvalue()
-            )
+            self.assertIn("Successfully updated risk_score for 2 users to 'Low'.", out.getvalue())

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -6,7 +6,10 @@ from django.core.management import CommandError, call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
-from impossible_travel.management.commands.setup_config import Command, parse_field_value
+from impossible_travel.management.commands.setup_config import (
+    Command,
+    parse_field_value,
+)
 from impossible_travel.models import (
     Config,
     User,
@@ -19,6 +22,7 @@ from impossible_travel.models import (
     get_default_risk_score_increment_alerts,
     get_default_vip_users,
 )
+
 
 class TestSetupConfigCommand(TestCase):
     def test_append_list_with_spaces(self):
@@ -43,7 +47,16 @@ class ManagementCommandsTestCase(TestCase):
 
     def test_options_values_passed(self):
         parser = Command().create_parser("manage.py", "setup_config")
-        options = parser.parse_args(["-o", "allowed_countries=[IT,RO]", "-r", "ignored_users=[admin]", "-a", "alert_is_vip_only=True"])
+        options = parser.parse_args(
+            [
+                "-o",
+                "allowed_countries=[IT,RO]",
+                "-r",
+                "ignored_users=[admin]",
+                "-a",
+                "alert_is_vip_only=True",
+            ]
+        )
         self.assertEqual(options.override, ["allowed_countries=[IT,RO]"])
         self.assertEqual(options.remove, ["ignored_users=[admin]"])
         self.assertEqual(options.append, ["alert_is_vip_only=True"])
@@ -91,20 +104,29 @@ class ManagementCommandsTestCase(TestCase):
         config.refresh_from_db()
         # check updated config values
         self.assertTrue(config.ignore_mobile_logins)
-        self.assertListEqual(config.filtered_alerts_types, ["New Device", "User Risk Threshold"])
+        self.assertListEqual(
+            config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
+        )
         self.assertEqual(config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM)
         self.assertEqual(config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM)
 
     def test_handle_set_default_values_force(self):
         # Testing the option --set-default-values (force mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
+        config_editable_fields = [
+            f.name
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        ]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
         self.config.alert_is_vip_only = True
         self.config.alert_minimum_risk_score = UserRiskScoreType.MEDIUM
-        self.config.risk_score_increment_alerts = [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY]
+        self.config.risk_score_increment_alerts = [
+            AlertDetectionType.NEW_COUNTRY,
+            AlertDetectionType.ATYPICAL_COUNTRY,
+        ]
         self.config.ignored_ips = ["9.9.9.9", "4.5.4.5"]
         self.config.ignored_ISPs = ["isp1"]
         self.config.atypical_country_days = 80
@@ -114,7 +136,9 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+        )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -128,34 +152,67 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertFalse(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, get_default_risk_score_increment_alerts())
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts,
+            get_default_risk_score_increment_alerts(),
+        )
         self.assertListEqual(self.config.ignored_ips, get_default_ignored_ips())
-        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
+        self.assertListEqual(
+            self.config.allowed_countries, get_default_allowed_countries()
+        )
         self.assertListEqual(self.config.ignored_ISPs, get_default_ignored_ISPs())
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
+        self.assertListEqual(
+            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+        )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
-        self.assertEqual(self.config.distance_accepted, settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED)
-        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
-        self.assertEqual(self.config.atypical_country_days, settings.CERTEGO_BUFFALOGS_ATYPICAL_COUNTRY_DAYS)
-        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
-        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
-        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
-        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
+        self.assertEqual(
+            self.config.distance_accepted,
+            settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
+        )
+        self.assertEqual(
+            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+        )
+        self.assertEqual(
+            self.config.atypical_country_days,
+            settings.CERTEGO_BUFFALOGS_ATYPICAL_COUNTRY_DAYS,
+        )
+        self.assertEqual(
+            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
+        )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
-        self.assertEqual(self.config.user_learning_period, settings.CERTEGO_BUFFALOGS_USER_LEARNING_PERIOD)
+        self.assertEqual(
+            self.config.user_learning_period,
+            settings.CERTEGO_BUFFALOGS_USER_LEARNING_PERIOD,
+        )
 
     def test_handle_set_default_values_safe(self):
         # Testing the option --set-default-values (safe mode)
         # Check that if new fields in the Config model have been added, they should be integrated into this test
-        config_editable_fields = [f.name for f in Config._meta.get_fields() if isinstance(f, Field) and f.editable and not f.auto_created]
+        config_editable_fields = [
+            f.name
+            for f in Config._meta.get_fields()
+            if isinstance(f, Field) and f.editable and not f.auto_created
+        ]
         self.assertEqual(22, len(config_editable_fields))
         # Put random values into fields
         self.config.ignored_users = ["blabla", "user2"]
         self.config.alert_is_vip_only = True
         self.config.alert_minimum_risk_score = UserRiskScoreType.MEDIUM
-        self.config.risk_score_increment_alerts = [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY]
+        self.config.risk_score_increment_alerts = [
+            AlertDetectionType.NEW_COUNTRY,
+            AlertDetectionType.ATYPICAL_COUNTRY,
+        ]
         self.config.ignored_ips = ["9.9.9.9", "4.5.4.5"]
         self.config.ignored_ISPs = ["isp1"]
         self.config.atypical_country_days = 80
@@ -166,7 +223,9 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"])
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+        )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
@@ -180,20 +239,40 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
-        self.assertListEqual(self.config.risk_score_increment_alerts, [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY])
+        self.assertListEqual(
+            self.config.risk_score_increment_alerts,
+            [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY],
+        )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
-        self.assertListEqual(self.config.allowed_countries, get_default_allowed_countries())
+        self.assertListEqual(
+            self.config.allowed_countries, get_default_allowed_countries()
+        )
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertTrue(self.config.ignore_mobile_logins)
-        self.assertListEqual(self.config.filtered_alerts_types, get_default_filtered_alerts_types())
+        self.assertListEqual(
+            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+        )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
-        self.assertEqual(self.config.distance_accepted, settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED)
-        self.assertEqual(self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED)
+        self.assertEqual(
+            self.config.distance_accepted,
+            settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
+        )
+        self.assertEqual(
+            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+        )
         self.assertEqual(self.config.atypical_country_days, 80)
-        self.assertEqual(self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS)
-        self.assertEqual(self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS)
-        self.assertEqual(self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS)
-        self.assertEqual(self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS)
+        self.assertEqual(
+            self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+        )
+        self.assertEqual(
+            self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
+        )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
         self.assertEqual(self.config.user_learning_period, 20)
@@ -205,12 +284,18 @@ class ManagementCommandsTestCase(TestCase):
         # 1. Single element missing "="
         with self.assertRaises(CommandError) as cm:
             call_command("setup_config", "-a", "ignored_users lorygold")
-        self.assertIn("Invalid syntax 'ignored_users lorygold': must be FIELD=VALUE", str(cm.exception))
+        self.assertIn(
+            "Invalid syntax 'ignored_users lorygold': must be FIELD=VALUE",
+            str(cm.exception),
+        )
 
         # 2. List missing "="
         with self.assertRaises(CommandError) as cm:
             call_command("setup_config", "-a", "enabled_users [lorygold]")
-        self.assertIn("Invalid syntax 'enabled_users [lorygold]': must be FIELD=VALUE", str(cm.exception))
+        self.assertIn(
+            "Invalid syntax 'enabled_users [lorygold]': must be FIELD=VALUE",
+            str(cm.exception),
+        )
 
         # 3. Field not existing
         with self.assertRaises(CommandError) as cm:
@@ -228,19 +313,29 @@ class ManagementCommandsTestCase(TestCase):
         actual_field_str, actual_value_str = parse_field_value("enabled_users=admin")
         self.assertEqual(actual_field_str, "enabled_users")
         self.assertEqual(actual_value_str, "admin")
-        actual_field_list, actual_value_list = parse_field_value("ignored_users=[lorygold]")
+        actual_field_list, actual_value_list = parse_field_value(
+            "ignored_users=[lorygold]"
+        )
         self.assertEqual(actual_field_list, "ignored_users")
         self.assertEqual(actual_value_list, ["lorygold"])
-        actual_field_list2, actual_value_list2 = parse_field_value('vip_users=["lory", "gold"]')
+        actual_field_list2, actual_value_list2 = parse_field_value(
+            'vip_users=["lory", "gold"]'
+        )
         self.assertEqual(actual_field_list2, "vip_users")
         self.assertListEqual(actual_value_list2, ["lory", "gold"])
 
     def test_parse_field_value_list_multiple_values_correct(self):
         # Testing the parse_field_value function with multiple str/regex values for a str list field
-        actual_field_list, actual_value_list = parse_field_value("enabled_users=[admin@gmaail.com, lory.gold, pluto123]")
+        actual_field_list, actual_value_list = parse_field_value(
+            "enabled_users=[admin@gmaail.com, lory.gold, pluto123]"
+        )
         self.assertEqual(actual_field_list, "enabled_users")
-        self.assertEqual(actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"])
-        actual_field_regex, actual_value_regex = parse_field_value("enabled_users=[*1.@*, *@acompany_name.com, pluto]")
+        self.assertEqual(
+            actual_value_list, ["admin@gmaail.com", "lory.gold", "pluto123"]
+        )
+        actual_field_regex, actual_value_regex = parse_field_value(
+            "enabled_users=[*1.@*, *@acompany_name.com, pluto]"
+        )
         self.assertEqual(actual_field_regex, "enabled_users")
         self.assertEqual(actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"])
 
@@ -282,19 +377,26 @@ class ResetUserRiskScoreCommandTests(TestCase):
 
     def test_update_single_user_success(self):
         out = io.StringIO()
-        call_command("reset_user_risk_score", username="alice", risk_score="Medium", stdout=out)
+        call_command(
+            "reset_user_risk_score", username="alice", risk_score="Medium", stdout=out
+        )
         alice = User.objects.get(username="alice")
         bob = User.objects.get(username="bob")
         self.assertEqual(alice.risk_score, "Medium")
         # other users unchanged
         self.assertEqual(bob.risk_score, "Low")
-        self.assertIn("Successfully updated risk_score for user 'alice' to 'Medium'.", out.getvalue())
+        self.assertIn(
+            "Successfully updated risk_score for user 'alice' to 'Medium'.",
+            out.getvalue(),
+        )
 
     def test_bulk_update_success(self):
         out = io.StringIO()
         call_command("reset_user_risk_score", risk_score="No risk", stdout=out)
         self.assertEqual(User.objects.filter(risk_score="No risk").count(), 2)
-        self.assertIn("Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue())
+        self.assertIn(
+            "Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue()
+        )
 
     def test_invalid_risk_score_raises(self):
         with self.assertRaises(CommandError) as cm:
@@ -314,15 +416,21 @@ class ResetUserRiskScoreCommandTests(TestCase):
         out = io.StringIO()
         # default should be 'No risk'
         call_command("reset_user_risk_score", stdout=out)
-        self.assertEqual(User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2)
+        self.assertEqual(
+            User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2
+        )
 
     def test_single_user_triggers_save(self):
-        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save:
+        with patch(
+            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+        ) as mock_save:
             call_command("reset_user_risk_score", username="alice", risk_score="Low")
             self.assertTrue(mock_save.called)
 
     def test_bulk_update_uses_update_not_save(self):
-        with patch("impossible_travel.management.commands.reset_user_risk_score.User.save") as mock_save, patch(
+        with patch(
+            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+        ) as mock_save, patch(
             "impossible_travel.management.commands.reset_user_risk_score.User.objects.update"
         ) as mock_update:
             mock_update.return_value = 2
@@ -330,4 +438,6 @@ class ResetUserRiskScoreCommandTests(TestCase):
             call_command("reset_user_risk_score", risk_score="Low", stdout=out)
             mock_update.assert_called_once_with(risk_score="Low")
             self.assertFalse(mock_save.called)
-            self.assertIn("Successfully updated risk_score for 2 users to 'Low'.", out.getvalue())
+            self.assertIn(
+                "Successfully updated risk_score for 2 users to 'Low'.", out.getvalue()
+            )

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -20,6 +20,20 @@ from impossible_travel.models import (
     get_default_vip_users,
 )
 
+class TestSetupConfigCommand(TestCase):
+    def test_append_list_with_spaces(self):
+        call_command(
+            "setup_config",
+            "-a",
+            "filtered_alerts_types=['New Device', 'User Risk Threshold', 'Anonymous IP Login']",
+        )
+
+        config = Config.objects.get(id=1)
+        self.assertEqual(
+            config.filtered_alerts_types,
+            ["New Device", "User Risk Threshold", "Anonymous IP Login"],
+        )
+
 
 class ManagementCommandsTestCase(TestCase):
     def setUp(self):

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -8,7 +8,6 @@ from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
 
 # isort: off
-# fmt: off
 from impossible_travel.management.commands.setup_config import (
     Command,
     parse_field_value,
@@ -25,7 +24,7 @@ from impossible_travel.models import (
     get_default_risk_score_increment_alerts,
     get_default_vip_users,
 )
-# fmt: on
+
 # isort: on
 
 
@@ -81,13 +80,11 @@ class ManagementCommandsTestCase(TestCase):
         self.assertFalse(config.ignore_mobile_logins)
         self.assertListEqual(config.filtered_alerts_types, [])
         self.assertEqual(
-            config.alert_minimum_risk_score,
-            UserRiskScoreType.NO_RISK,
-        )
+            config.alert_minimum_risk_score, UserRiskScoreType.NO_RISK
+        )  # noqa: E501
         self.assertEqual(
-            config.threshold_user_risk_alert,
-            UserRiskScoreType.NO_RISK,
-        )
+            config.threshold_user_risk_alert, UserRiskScoreType.NO_RISK
+        )  # noqa: E501
         # simulate mgmt command parsing
         args = [
             "-o",
@@ -120,13 +117,11 @@ class ManagementCommandsTestCase(TestCase):
             config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
         )
         self.assertEqual(
-            config.alert_minimum_risk_score,
-            UserRiskScoreType.MEDIUM,
-        )
+            config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM
+        )  # noqa: E501
         self.assertEqual(
-            config.threshold_user_risk_alert,
-            UserRiskScoreType.MEDIUM,
-        )
+            config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM
+        )  # noqa: E501
 
     def test_handle_set_default_values_force(self):
         # Testing the option --set-default-values (force mode)
@@ -168,13 +163,11 @@ class ManagementCommandsTestCase(TestCase):
         self.config.refresh_from_db()
         # check the corrispondence with the default values
         self.assertListEqual(
-            self.config.ignored_users,
-            get_default_ignored_users(),
-        )
+            self.config.ignored_users, get_default_ignored_users()
+        )  # noqa: E501
         self.assertListEqual(
-            self.config.enabled_users,
-            get_default_enabled_users(),
-        )
+            self.config.enabled_users, get_default_enabled_users()
+        )  # noqa: E501
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertFalse(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
@@ -183,16 +176,14 @@ class ManagementCommandsTestCase(TestCase):
             get_default_risk_score_increment_alerts(),
         )
         self.assertListEqual(
-            self.config.ignored_ips,
-            get_default_ignored_ips(),
-        )
+            self.config.ignored_ips, get_default_ignored_ips()
+        )  # noqa: E501
         self.assertListEqual(
             self.config.allowed_countries, get_default_allowed_countries()
         )
         self.assertListEqual(
-            self.config.ignored_ISPs,
-            get_default_ignored_ISPs(),
-        )
+            self.config.ignored_ISPs, get_default_ignored_ISPs()
+        )  # noqa: E501
         self.assertTrue(self.config.ignore_mobile_logins)
         self.assertListEqual(
             self.config.filtered_alerts_types,
@@ -227,9 +218,8 @@ class ManagementCommandsTestCase(TestCase):
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(
-            self.config.ignored_impossible_travel_countries_couples,
-            [],
-        )
+            self.config.ignored_impossible_travel_countries_couples, []
+        )  # noqa: E501
         self.assertEqual(
             self.config.user_learning_period,
             settings.CERTEGO_BUFFALOGS_USER_LEARNING_PERIOD,
@@ -279,9 +269,8 @@ class ManagementCommandsTestCase(TestCase):
         # (not for already populated fields)
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertListEqual(
-            self.config.enabled_users,
-            get_default_enabled_users(),
-        )
+            self.config.enabled_users, get_default_enabled_users()
+        )  # noqa: E501
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
@@ -328,9 +317,8 @@ class ManagementCommandsTestCase(TestCase):
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(
-            self.config.ignored_impossible_travel_countries_couples,
-            [],
-        )
+            self.config.ignored_impossible_travel_countries_couples, []
+        )  # noqa: E501
         self.assertEqual(self.config.user_learning_period, 20)
 
     # === Tests for setup_config.py mgmt command -
@@ -358,9 +346,8 @@ class ManagementCommandsTestCase(TestCase):
         with self.assertRaises(CommandError) as cm:
             call_command("setup_config", "-a", "nonexistent_field=lorygold")
         self.assertIn(
-            "Field 'nonexistent_field' does not exist",
-            str(cm.exception),
-        )
+            "Field 'nonexistent_field' does not exist", str(cm.exception)
+        )  # noqa: E501
 
     def test_parse_field_value_empty_list(self):
         # Testing the parse_field_value function with an empty list

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -6,6 +6,9 @@ from django.core.management import CommandError, call_command
 from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
+
+# isort: off
+# fmt: off
 from impossible_travel.management.commands.setup_config import (
     Command,
     parse_field_value,
@@ -22,6 +25,8 @@ from impossible_travel.models import (
     get_default_risk_score_increment_alerts,
     get_default_vip_users,
 )
+# fmt: on
+# isort: on
 
 
 class TestSetupConfigCommand(TestCase):
@@ -76,10 +81,12 @@ class ManagementCommandsTestCase(TestCase):
         self.assertFalse(config.ignore_mobile_logins)
         self.assertListEqual(config.filtered_alerts_types, [])
         self.assertEqual(
-            config.alert_minimum_risk_score, UserRiskScoreType.NO_RISK
+            config.alert_minimum_risk_score,
+            UserRiskScoreType.NO_RISK,
         )
         self.assertEqual(
-            config.threshold_user_risk_alert, UserRiskScoreType.NO_RISK
+            config.threshold_user_risk_alert,
+            UserRiskScoreType.NO_RISK,
         )
         # simulate mgmt command parsing
         args = [
@@ -113,10 +120,12 @@ class ManagementCommandsTestCase(TestCase):
             config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
         )
         self.assertEqual(
-            config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM
+            config.alert_minimum_risk_score,
+            UserRiskScoreType.MEDIUM,
         )
         self.assertEqual(
-            config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM
+            config.threshold_user_risk_alert,
+            UserRiskScoreType.MEDIUM,
         )
 
     def test_handle_set_default_values_force(self):
@@ -159,10 +168,12 @@ class ManagementCommandsTestCase(TestCase):
         self.config.refresh_from_db()
         # check the corrispondence with the default values
         self.assertListEqual(
-            self.config.ignored_users, get_default_ignored_users()
+            self.config.ignored_users,
+            get_default_ignored_users(),
         )
         self.assertListEqual(
-            self.config.enabled_users, get_default_enabled_users()
+            self.config.enabled_users,
+            get_default_enabled_users(),
         )
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertFalse(self.config.alert_is_vip_only)
@@ -172,13 +183,15 @@ class ManagementCommandsTestCase(TestCase):
             get_default_risk_score_increment_alerts(),
         )
         self.assertListEqual(
-            self.config.ignored_ips, get_default_ignored_ips()
+            self.config.ignored_ips,
+            get_default_ignored_ips(),
         )
         self.assertListEqual(
             self.config.allowed_countries, get_default_allowed_countries()
         )
         self.assertListEqual(
-            self.config.ignored_ISPs, get_default_ignored_ISPs()
+            self.config.ignored_ISPs,
+            get_default_ignored_ISPs(),
         )
         self.assertTrue(self.config.ignore_mobile_logins)
         self.assertListEqual(
@@ -214,7 +227,8 @@ class ManagementCommandsTestCase(TestCase):
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(
-            self.config.ignored_impossible_travel_countries_couples, []
+            self.config.ignored_impossible_travel_countries_couples,
+            [],
         )
         self.assertEqual(
             self.config.user_learning_period,
@@ -265,7 +279,8 @@ class ManagementCommandsTestCase(TestCase):
         # (not for already populated fields)
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
         self.assertListEqual(
-            self.config.enabled_users, get_default_enabled_users()
+            self.config.enabled_users,
+            get_default_enabled_users(),
         )
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertTrue(self.config.alert_is_vip_only)
@@ -313,7 +328,8 @@ class ManagementCommandsTestCase(TestCase):
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
         self.assertEqual(
-            self.config.ignored_impossible_travel_countries_couples, []
+            self.config.ignored_impossible_travel_countries_couples,
+            [],
         )
         self.assertEqual(self.config.user_learning_period, 20)
 
@@ -342,7 +358,8 @@ class ManagementCommandsTestCase(TestCase):
         with self.assertRaises(CommandError) as cm:
             call_command("setup_config", "-a", "nonexistent_field=lorygold")
         self.assertIn(
-            "Field 'nonexistent_field' does not exist", str(cm.exception)
+            "Field 'nonexistent_field' does not exist",
+            str(cm.exception),
         )
 
     def test_parse_field_value_empty_list(self):
@@ -355,7 +372,7 @@ class ManagementCommandsTestCase(TestCase):
         # Testing the parse_field_value function with a str values
         # for a list field
         actual_field_str, actual_value_str = parse_field_value(
-            "enabled_users=admin"
+            "enabled_users=admin",
         )
         self.assertEqual(actual_field_str, "enabled_users")
         self.assertEqual(actual_value_str, "admin")
@@ -385,7 +402,8 @@ class ManagementCommandsTestCase(TestCase):
         )
         self.assertEqual(actual_field_regex, "enabled_users")
         self.assertEqual(
-            actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"]
+            actual_value_regex,
+            ["*1.@*", "*@acompany_name.com", "pluto"],
         )
 
     def test_parse_field_value_ignores_empty_values_in_list(self):
@@ -413,7 +431,7 @@ class ManagementCommandsTestCase(TestCase):
     def test_parse_field_value_numeric(self):
         # Testing the parse_field_value function with numeric value
         field_integer, value_integer = parse_field_value(
-            "distance_accepted=1000"
+            "distance_accepted=1000",
         )
         self.assertEqual(field_integer, "distance_accepted")
         self.assertEqual(value_integer, 1000)
@@ -466,7 +484,9 @@ class ResetUserRiskScoreCommandTests(TestCase):
     def test_nonexistent_user_raises(self):
         with self.assertRaises(CommandError) as cm:
             call_command(
-                "reset_user_risk_score", username="ghost", risk_score="Low"
+                "reset_user_risk_score",
+                username="ghost",
+                risk_score="Low",
             )
         self.assertIn("User 'ghost' does not exist", str(cm.exception))
 
@@ -476,32 +496,33 @@ class ResetUserRiskScoreCommandTests(TestCase):
         call_command("reset_user_risk_score", stdout=out)
         self.assertEqual(
             User.objects.filter(
-                risk_score=UserRiskScoreType.NO_RISK.value
+                risk_score=UserRiskScoreType.NO_RISK.value,
             ).count(),
             2,
         )
 
-    def test_single_user_triggers_save(self):
-        with patch(
-            "impossible_travel.management.commands.reset_user_risk_score"
-            ".User.save"
-        ) as mock_save:
+        cmd_base = "impossible_travel.management.commands"
+        path_save = f"{cmd_base}.reset_user_risk_score.User.save"
+        with patch(path_save) as mock_save:
             call_command(
-                "reset_user_risk_score", username="alice", risk_score="Low"
+                "reset_user_risk_score",
+                username="alice",
+                risk_score="Low",
             )
             self.assertTrue(mock_save.called)
 
     def test_bulk_update_uses_update_not_save(self):
-        with patch(
-            "impossible_travel.management.commands.reset_user_risk_score"
-            ".User.save"
-        ) as mock_save, patch(
-            "impossible_travel.management.commands.reset_user_risk_score"
-            ".User.objects.update"
-        ) as mock_update:
+        cmd_base = "impossible_travel.management.commands"
+        path_save = f"{cmd_base}.reset_user_risk_score.User.save"
+        path_update = f"{cmd_base}.reset_user_risk_score.User.objects.update"
+        with patch(path_save) as mock_save, patch(path_update) as mock_update:
             mock_update.return_value = 2
             out = io.StringIO()
-            call_command("reset_user_risk_score", risk_score="Low", stdout=out)
+            call_command(
+                "reset_user_risk_score",
+                risk_score="Low",
+                stdout=out,
+            )
             mock_update.assert_called_once_with(risk_score="Low")
             self.assertFalse(mock_save.called)
             self.assertIn(

--- a/buffalogs/impossible_travel/tests/task/test_management_commands.py
+++ b/buffalogs/impossible_travel/tests/task/test_management_commands.py
@@ -7,16 +7,21 @@ from django.db.models.fields import Field
 from django.test import TestCase
 from impossible_travel.constants import AlertDetectionType, UserRiskScoreType
 from impossible_travel.management.commands.setup_config import (
-    Command, parse_field_value)
-from impossible_travel.models import (Config, User,
-                                      get_default_allowed_countries,
-                                      get_default_enabled_users,
-                                      get_default_filtered_alerts_types,
-                                      get_default_ignored_ips,
-                                      get_default_ignored_ISPs,
-                                      get_default_ignored_users,
-                                      get_default_risk_score_increment_alerts,
-                                      get_default_vip_users)
+    Command,
+    parse_field_value,
+)
+from impossible_travel.models import (
+    Config,
+    User,
+    get_default_allowed_countries,
+    get_default_enabled_users,
+    get_default_filtered_alerts_types,
+    get_default_ignored_ips,
+    get_default_ignored_ISPs,
+    get_default_ignored_users,
+    get_default_risk_score_increment_alerts,
+    get_default_vip_users,
+)
 
 
 class TestSetupConfigCommand(TestCase):
@@ -24,12 +29,11 @@ class TestSetupConfigCommand(TestCase):
         call_command(
             "setup_config",
             "-a",
-            "filtered_alerts_types=['New Device', 'User Risk Threshold', 'Anonymous IP Login']",
+            "filtered_alerts_types=['New Device', 'User Risk Threshold', "
+            "'Anonymous IP Login']",
         )
 
         config = Config.objects.get(id=1)
-
-        # Order is NOT guaranteed → compare contents only
         self.assertCountEqual(
             config.filtered_alerts_types,
             ["New Device", "User Risk Threshold", "Anonymous IP Login"],
@@ -71,8 +75,12 @@ class ManagementCommandsTestCase(TestCase):
         # check initial state
         self.assertFalse(config.ignore_mobile_logins)
         self.assertListEqual(config.filtered_alerts_types, [])
-        self.assertEqual(config.alert_minimum_risk_score, UserRiskScoreType.NO_RISK)
-        self.assertEqual(config.threshold_user_risk_alert, UserRiskScoreType.NO_RISK)
+        self.assertEqual(
+            config.alert_minimum_risk_score, UserRiskScoreType.NO_RISK
+        )
+        self.assertEqual(
+            config.threshold_user_risk_alert, UserRiskScoreType.NO_RISK
+        )
         # simulate mgmt command parsing
         args = [
             "-o",
@@ -104,12 +112,17 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(
             config.filtered_alerts_types, ["New Device", "User Risk Threshold"]
         )
-        self.assertEqual(config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM)
-        self.assertEqual(config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM)
+        self.assertEqual(
+            config.alert_minimum_risk_score, UserRiskScoreType.MEDIUM
+        )
+        self.assertEqual(
+            config.threshold_user_risk_alert, UserRiskScoreType.MEDIUM
+        )
 
     def test_handle_set_default_values_force(self):
         # Testing the option --set-default-values (force mode)
-        # Check that if new fields in the Config model have been added, they should be integrated into this test
+        # Check that if new fields in the Config model have been added,
+        # they should be integrated into this test
         config_editable_fields = [
             f.name
             for f in Config._meta.get_fields()
@@ -134,7 +147,8 @@ class ManagementCommandsTestCase(TestCase):
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
         self.assertListEqual(
-            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+            self.config.risk_score_increment_alerts,
+            ["New Country", "Atypical Country"],
         )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
@@ -144,8 +158,12 @@ class ManagementCommandsTestCase(TestCase):
         call_command("setup_config", "--set-default-values", "--force")
         self.config.refresh_from_db()
         # check the corrispondence with the default values
-        self.assertListEqual(self.config.ignored_users, get_default_ignored_users())
-        self.assertListEqual(self.config.enabled_users, get_default_enabled_users())
+        self.assertListEqual(
+            self.config.ignored_users, get_default_ignored_users()
+        )
+        self.assertListEqual(
+            self.config.enabled_users, get_default_enabled_users()
+        )
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertFalse(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
@@ -153,14 +171,19 @@ class ManagementCommandsTestCase(TestCase):
             self.config.risk_score_increment_alerts,
             get_default_risk_score_increment_alerts(),
         )
-        self.assertListEqual(self.config.ignored_ips, get_default_ignored_ips())
+        self.assertListEqual(
+            self.config.ignored_ips, get_default_ignored_ips()
+        )
         self.assertListEqual(
             self.config.allowed_countries, get_default_allowed_countries()
         )
-        self.assertListEqual(self.config.ignored_ISPs, get_default_ignored_ISPs())
+        self.assertListEqual(
+            self.config.ignored_ISPs, get_default_ignored_ISPs()
+        )
         self.assertTrue(self.config.ignore_mobile_logins)
         self.assertListEqual(
-            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+            self.config.filtered_alerts_types,
+            get_default_filtered_alerts_types(),
         )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
@@ -168,7 +191,8 @@ class ManagementCommandsTestCase(TestCase):
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
         self.assertEqual(
-            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+            self.config.vel_accepted,
+            settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED,
         )
         self.assertEqual(
             self.config.atypical_country_days,
@@ -178,16 +202,20 @@ class ManagementCommandsTestCase(TestCase):
             self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
         )
         self.assertEqual(
-            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+            self.config.login_max_days,
+            settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS,
         )
         self.assertEqual(
-            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+            self.config.alert_max_days,
+            settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS,
         )
         self.assertEqual(
             self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
-        self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
+        self.assertEqual(
+            self.config.ignored_impossible_travel_countries_couples, []
+        )
         self.assertEqual(
             self.config.user_learning_period,
             settings.CERTEGO_BUFFALOGS_USER_LEARNING_PERIOD,
@@ -195,7 +223,8 @@ class ManagementCommandsTestCase(TestCase):
 
     def test_handle_set_default_values_safe(self):
         # Testing the option --set-default-values (safe mode)
-        # Check that if new fields in the Config model have been added, they should be integrated into this test
+        # Check that if new fields in the Config model have been added,
+        # they should be integrated into this test
         config_editable_fields = [
             f.name
             for f in Config._meta.get_fields()
@@ -221,24 +250,32 @@ class ManagementCommandsTestCase(TestCase):
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
         self.assertListEqual(
-            self.config.risk_score_increment_alerts, ["New Country", "Atypical Country"]
+            self.config.risk_score_increment_alerts,
+            ["New Country", "Atypical Country"],
         )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertEqual(self.config.atypical_country_days, 80)
         self.assertEqual(self.config.user_learning_period, 20)
-        # call the mgmt command with the --set-default-values option (safe mode)
+        # call the mgmt command with the --set-default-values option
+        # (safe mode)
         call_command("setup_config", "--set-default-values")
         self.config.refresh_from_db()
-        # check the corrispondence with the default values (not for already populated fields)
+        # check the corrispondence with the default values
+        # (not for already populated fields)
         self.assertListEqual(self.config.ignored_users, ["blabla", "user2"])
-        self.assertListEqual(self.config.enabled_users, get_default_enabled_users())
+        self.assertListEqual(
+            self.config.enabled_users, get_default_enabled_users()
+        )
         self.assertListEqual(self.config.vip_users, get_default_vip_users())
         self.assertTrue(self.config.alert_is_vip_only)
         self.assertEqual(self.config.alert_minimum_risk_score, "Medium")
         self.assertListEqual(
             self.config.risk_score_increment_alerts,
-            [AlertDetectionType.NEW_COUNTRY, AlertDetectionType.ATYPICAL_COUNTRY],
+            [
+                AlertDetectionType.NEW_COUNTRY,
+                AlertDetectionType.ATYPICAL_COUNTRY,
+            ],
         )
         self.assertListEqual(self.config.ignored_ips, ["9.9.9.9", "4.5.4.5"])
         self.assertListEqual(
@@ -247,7 +284,8 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(self.config.ignored_ISPs, ["isp1"])
         self.assertTrue(self.config.ignore_mobile_logins)
         self.assertListEqual(
-            self.config.filtered_alerts_types, get_default_filtered_alerts_types()
+            self.config.filtered_alerts_types,
+            get_default_filtered_alerts_types(),
         )
         self.assertEqual(self.config.threshold_user_risk_alert, "Medium")
         self.assertEqual(
@@ -255,26 +293,32 @@ class ManagementCommandsTestCase(TestCase):
             settings.CERTEGO_BUFFALOGS_DISTANCE_KM_ACCEPTED,
         )
         self.assertEqual(
-            self.config.vel_accepted, settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED
+            self.config.vel_accepted,
+            settings.CERTEGO_BUFFALOGS_VEL_TRAVEL_ACCEPTED,
         )
         self.assertEqual(self.config.atypical_country_days, 80)
         self.assertEqual(
             self.config.user_max_days, settings.CERTEGO_BUFFALOGS_USER_MAX_DAYS
         )
         self.assertEqual(
-            self.config.login_max_days, settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS
+            self.config.login_max_days,
+            settings.CERTEGO_BUFFALOGS_LOGIN_MAX_DAYS,
         )
         self.assertEqual(
-            self.config.alert_max_days, settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS
+            self.config.alert_max_days,
+            settings.CERTEGO_BUFFALOGS_ALERT_MAX_DAYS,
         )
         self.assertEqual(
             self.config.ip_max_days, settings.CERTEGO_BUFFALOGS_IP_MAX_DAYS
         )
         self.assertTrue(self.config.ignored_impossible_travel_all_same_country)
-        self.assertEqual(self.config.ignored_impossible_travel_countries_couples, [])
+        self.assertEqual(
+            self.config.ignored_impossible_travel_countries_couples, []
+        )
         self.assertEqual(self.config.user_learning_period, 20)
 
-    # === Tests for setup_config.py mgmt command - parse_field_value function ===
+    # === Tests for setup_config.py mgmt command -
+    # parse_field_value function ===
 
     def test_parse_field_value_CommandError(self):
         # Testing the parse_field_value function for the CommandError exception
@@ -297,7 +341,9 @@ class ManagementCommandsTestCase(TestCase):
         # 3. Field not existing
         with self.assertRaises(CommandError) as cm:
             call_command("setup_config", "-a", "nonexistent_field=lorygold")
-        self.assertIn("Field 'nonexistent_field' does not exist", str(cm.exception))
+        self.assertIn(
+            "Field 'nonexistent_field' does not exist", str(cm.exception)
+        )
 
     def test_parse_field_value_empty_list(self):
         # Testing the parse_field_value function with an empty list
@@ -306,8 +352,11 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(actual_value, [])
 
     def test_parse_field_value_list_single_value_correct(self):
-        # Testing the parse_field_value function with a str values for a list field
-        actual_field_str, actual_value_str = parse_field_value("enabled_users=admin")
+        # Testing the parse_field_value function with a str values
+        # for a list field
+        actual_field_str, actual_value_str = parse_field_value(
+            "enabled_users=admin"
+        )
         self.assertEqual(actual_field_str, "enabled_users")
         self.assertEqual(actual_value_str, "admin")
         actual_field_list, actual_value_list = parse_field_value(
@@ -322,7 +371,8 @@ class ManagementCommandsTestCase(TestCase):
         self.assertListEqual(actual_value_list2, ["lory", "gold"])
 
     def test_parse_field_value_list_multiple_values_correct(self):
-        # Testing the parse_field_value function with multiple str/regex values for a str list field
+        # Testing the parse_field_value function with multiple str/regex
+        # values for a str list field
         actual_field_list, actual_value_list = parse_field_value(
             "enabled_users=[admin@gmaail.com, lory.gold, pluto123]"
         )
@@ -334,10 +384,13 @@ class ManagementCommandsTestCase(TestCase):
             "enabled_users=[*1.@*, *@acompany_name.com, pluto]"
         )
         self.assertEqual(actual_field_regex, "enabled_users")
-        self.assertEqual(actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"])
+        self.assertEqual(
+            actual_value_regex, ["*1.@*", "*@acompany_name.com", "pluto"]
+        )
 
     def test_parse_field_value_ignores_empty_values_in_list(self):
-        # Testing the parse_field_value function with some empty strings to be ignored
+        # Testing the parse_field_value function with some empty strings
+        # to be ignored
         field, value = parse_field_value("key=[a, , b,,c ]")
         self.assertEqual(field, "key")
         self.assertEqual(value, ["a", "b", "c"])
@@ -359,7 +412,9 @@ class ManagementCommandsTestCase(TestCase):
 
     def test_parse_field_value_numeric(self):
         # Testing the parse_field_value function with numeric value
-        field_integer, value_integer = parse_field_value("distance_accepted=1000")
+        field_integer, value_integer = parse_field_value(
+            "distance_accepted=1000"
+        )
         self.assertEqual(field_integer, "distance_accepted")
         self.assertEqual(value_integer, 1000)
         field_float, value_float = parse_field_value("vel_accepted=55.7")
@@ -375,7 +430,10 @@ class ResetUserRiskScoreCommandTests(TestCase):
     def test_update_single_user_success(self):
         out = io.StringIO()
         call_command(
-            "reset_user_risk_score", username="alice", risk_score="Medium", stdout=out
+            "reset_user_risk_score",
+            username="alice",
+            risk_score="Medium",
+            stdout=out,
         )
         alice = User.objects.get(username="alice")
         bob = User.objects.get(username="bob")
@@ -392,7 +450,8 @@ class ResetUserRiskScoreCommandTests(TestCase):
         call_command("reset_user_risk_score", risk_score="No risk", stdout=out)
         self.assertEqual(User.objects.filter(risk_score="No risk").count(), 2)
         self.assertIn(
-            "Successfully updated risk_score for 2 users to 'No risk'.", out.getvalue()
+            "Successfully updated risk_score for 2 users to 'No risk'.",
+            out.getvalue(),
         )
 
     def test_invalid_risk_score_raises(self):
@@ -406,7 +465,9 @@ class ResetUserRiskScoreCommandTests(TestCase):
 
     def test_nonexistent_user_raises(self):
         with self.assertRaises(CommandError) as cm:
-            call_command("reset_user_risk_score", username="ghost", risk_score="Low")
+            call_command(
+                "reset_user_risk_score", username="ghost", risk_score="Low"
+            )
         self.assertIn("User 'ghost' does not exist", str(cm.exception))
 
     def test_default_risk_score_used_for_bulk(self):
@@ -414,21 +475,29 @@ class ResetUserRiskScoreCommandTests(TestCase):
         # default should be 'No risk'
         call_command("reset_user_risk_score", stdout=out)
         self.assertEqual(
-            User.objects.filter(risk_score=UserRiskScoreType.NO_RISK.value).count(), 2
+            User.objects.filter(
+                risk_score=UserRiskScoreType.NO_RISK.value
+            ).count(),
+            2,
         )
 
     def test_single_user_triggers_save(self):
         with patch(
-            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+            "impossible_travel.management.commands.reset_user_risk_score"
+            ".User.save"
         ) as mock_save:
-            call_command("reset_user_risk_score", username="alice", risk_score="Low")
+            call_command(
+                "reset_user_risk_score", username="alice", risk_score="Low"
+            )
             self.assertTrue(mock_save.called)
 
     def test_bulk_update_uses_update_not_save(self):
         with patch(
-            "impossible_travel.management.commands.reset_user_risk_score.User.save"
+            "impossible_travel.management.commands.reset_user_risk_score"
+            ".User.save"
         ) as mock_save, patch(
-            "impossible_travel.management.commands.reset_user_risk_score.User.objects.update"
+            "impossible_travel.management.commands.reset_user_risk_score"
+            ".User.objects.update"
         ) as mock_update:
             mock_update.return_value = 2
             out = io.StringIO()
@@ -436,5 +505,6 @@ class ResetUserRiskScoreCommandTests(TestCase):
             mock_update.assert_called_once_with(risk_score="Low")
             self.assertFalse(mock_save.called)
             self.assertIn(
-                "Successfully updated risk_score for 2 users to 'Low'.", out.getvalue()
+                "Successfully updated risk_score for 2 users to 'Low'.",
+                out.getvalue(),
             )


### PR DESCRIPTION
- Fixes parsing of multi-value list flags in setup_config
- Adds coverage for edge cases
- Fully compliant with CI linters (black 26.1.0, isort 7.0.0, flake8 7.3.0)

Supersedes previous PR due to CI formatting artifacts.
