### PR TITLE
fix: setup_config accepts multiple values for list fields

### DIFF
--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -206,10 +206,8 @@ class Command(TaskLoggingCommand):
                     validator(value)
                 except ValidationError as e:
                     # Extract detailed error messages from ValidationError
-                    error_details = "; ".join(e.messages) if hasattr(e, 'messages') else str(e)
-                    raise CommandError(
-                        f"Validation error on field '{field}' with value '{value}': {error_details}"
-                    )
+                    error_details = "; ".join(e.messages) if hasattr(e, "messages") else str(e)
+                    raise CommandError(f"Validation error on field '{field}' with value '{value}': {error_details}")
 
             # Apply changes
             if is_list:
@@ -230,15 +228,12 @@ class Command(TaskLoggingCommand):
             setattr(config, field, current)
 
         # Validate filtered_alerts_types before saving
-        if hasattr(config, 'filtered_alerts_types') and config.filtered_alerts_types:
+        if hasattr(config, "filtered_alerts_types") and config.filtered_alerts_types:
             valid_choices = [choice[0] for choice in AlertDetectionType.choices]
             invalid_values = [val for val in config.filtered_alerts_types if val not in valid_choices]
-            
+
             if invalid_values:
-                raise CommandError(
-                    f"Invalid values in 'filtered_alerts_types': {invalid_values}. "
-                    f"Valid choices are: {valid_choices}"
-                )
+                raise CommandError(f"Invalid values in 'filtered_alerts_types': {invalid_values}. " f"Valid choices are: {valid_choices}")
 
         config.save()
         self.stdout.write(self.style.SUCCESS("Config updated successfully."))

--- a/buffalogs/impossible_travel/management/commands/setup_config.py
+++ b/buffalogs/impossible_travel/management/commands/setup_config.py
@@ -210,7 +210,9 @@ class Command(TaskLoggingCommand):
             if is_list:
                 current = current or []
                 if mode == "append":
-                    current += value
+                    # Only append values that don't already exist (make it idempotent)
+                    new_values = [v for v in value if v not in current]
+                    current += new_values
                 elif mode == "override":
                     current = value
                 elif mode == "remove":


### PR DESCRIPTION
## 🎯 Description

Fixes #499

The `setup_config` Django management command now correctly parses and accepts multiple values with spaces for list-type (ArrayField) configuration fields in a single invocation.

### Problem
Previously, attempting to pass multiple values with spaces would fail:

```bash
# ❌ Required workaround (multiple commands)
./manage.py setup_config -a filtered_alerts_types=['New Device']
./manage.py setup_config -a filtered_alerts_types=['User Risk Threshold']
./manage.py setup_config -a filtered_alerts_types=['Anonymous IP Login']
```

### Solution
Enhanced the `parse_field_value()` function with quote-aware CSV parsing and fixed validation logic to properly handle list values:

```bash
# ✅ Now works in a single command
./manage.py setup_config -a 'filtered_alerts_types=["New Device", "User Risk Threshold", "Anonymous IP Login"]'
```

---

## 🔧 Changes Made

### Modified Files
1. **`buffalogs/impossible_travel/management/commands/setup_config.py`**
   - Enhanced `parse_field_value()` with manual quote-aware CSV parsing
   - Supports single quotes, double quotes, and mixed formats
   - Always returns a list when brackets `[...]` are present
   - Fixed validation logic to validate the complete value instead of individual elements
   - Maintains 100% backward compatibility

2. **`buffalogs/impossible_travel/tests/task/test_management_commands.py`**
   - Added 7 comprehensive test cases
   - Tests all three modes: append (`-a`), override (`-o`), remove (`-r`)
   - Covers edge cases: empty lists, single values, multiple values, quotes

---

## ✅ Testing

### Test Results
```
✅ All 18 automated tests pass (100% success rate)
✅ All 7 manual integration tests pass
✅ Black formatting: PASSED
✅ isort: PASSED
✅ flake8: PASSED
```

### Manual Test Coverage
1. ✅ Multiple values with spaces in append mode
2. ✅ Multiple values with spaces in override mode
3. ✅ Multiple values with spaces in remove mode
4. ✅ Single-element lists return list type (fixed validation error)
5. ✅ Backward compatibility (values without spaces/quotes still work)
6. ✅ Empty lists handled correctly
7. ✅ **The exact case from issue #499 works perfectly**

### Test Commands
```bash
# Test 1: Append mode
./manage.py setup_config -a 'ignored_users=["admin user", "bot user"]'
# Result: ['admin user', 'bot user'] ✅

# Test 2: Override mode
./manage.py setup_config -o 'vip_users=["VIP One", "VIP Two", "VIP Three"]'
# Result: ['VIP One', 'VIP Two', 'VIP Three'] ✅

# Test 3: Remove mode
./manage.py setup_config -o 'enabled_users=["keep me", "remove 1", "remove 2"]'
./manage.py setup_config -r 'enabled_users=["remove 1", "remove 2"]'
# Result: ['keep me'] ✅

# Test 4: Backward compatibility
./manage.py setup_config -o 'allowed_countries=[Italy,Romania,France]'
# Result: ['Italy', 'Romania', 'France'] ✅

# Test 5: Issue #499 exact case
./manage.py setup_config -a 'filtered_alerts_types=["New Device", "User Risk Threshold", "Anonymous IP Login"]'
# Result: ['New Device', 'User Risk Threshold', 'Anonymous IP Login'] ✅
```

---

## 🔄 Backward Compatibility

✅ **100% backward compatible** - all existing command syntax continues to work:

```bash
# All these still work exactly as before
./manage.py setup_config -a ignored_users=admin
./manage.py setup_config -o allowed_countries=[Italy,Romania]
./manage.py setup_config -r vip_users=user1
```

---

## 📚 Implementation Details

### Quote-Aware CSV Parsing
The fix uses **manual character-by-character parsing** to handle quoted CSV values:

- Tracks quote state (in/out of quotes, which quote character)
- Splits on commas only when outside quotes
- Strips quotes from final values
- Handles edge cases (empty strings, mixed quotes, etc.)

### Validation Fix
Fixed validation logic to validate the **complete value** for list fields instead of iterating through individual elements. ArrayField validators expect to receive the entire list, not individual strings.

**Before (❌ Bug):**
```python
values_to_validate = value if is_list else [value]
for val in values_to_validate:  # Iterates individual elements
    validator(val)  # Fails: validator expects list, gets string
```

**After (✅ Fixed):**
```python
for validator in getattr(field_obj, "validators", []):
    validator(value)  # Validates complete list
```

---

## 🎯 Impact

**Before:**
- ❌ Multiple values with spaces required multiple commands
- ❌ Poor user experience
- ❌ Inconsistent with help text examples

**After:**
- ✅ Single command handles all cases
- ✅ Intuitive syntax matching documentation
- ✅ Improved developer experience

---

## 📋 Checklist

- [x] Code follows project style guidelines (Black, isort, flake8)
- [x] Tests added and passing (7 new tests + 18 existing tests)
- [x] Backward compatibility maintained
- [x] Documentation updated (enhanced docstring)
- [x] Manual testing completed (7/7 tests passed)
- [x] Commit message follows convention
- [x] PR targets `develop` branch
- [x] PR linked to issue #499

---

## 🔧 **UPDATE: Idempotent Append Mode (2026-02-07)**

### Issue Reported by @Lorygold
Running the command multiple times was appending duplicate values:
```bash
# First run
./manage.py setup_config -a "filtered_alerts_types=['New Device','User Risk Threshold']"
# Result: ['New Device', 'User Risk Threshold'] ✅

# Second run (same command)
./manage.py setup_config -a "filtered_alerts_types=['New Device','User Risk Threshold']"
# Result: ['New Device', 'User Risk Threshold', 'New Device', 'User Risk Threshold'] ❌
```

### Fix Applied
Modified the append logic to filter out existing values before adding:
```python
if mode == "append":
    # Only append values that don't already exist (make it idempotent)
    new_values = [v for v in value if v not in current]
    current += new_values
```

### Benefits
- ✅ **Idempotent:** Running the command multiple times produces the same result
- ✅ **Safe for automation:** Can be used in CI/CD pipelines without risk of duplicates
- ✅ **Configuration management friendly:** Compatible with tools like Ansible, Terraform
- ✅ **Tested:** Added `test_setup_config_append_idempotent` (all 26 tests pass)

### Test Results
```bash
# Run command 3 times
./manage.py setup_config -a "filtered_alerts_types=['User Risk Threshold','New Device']"
./manage.py setup_config -a "filtered_alerts_types=['User Risk Threshold','New Device']"
./manage.py setup_config -a "filtered_alerts_types=['User Risk Threshold','New Device']"

# Result: ['User Risk Threshold', 'New Device'] ✅ (no duplicates!)
```

---

